### PR TITLE
Add on-disk Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ RaspberryPi image creator to build OLIP or Kiwix Hotspot off [`base-image`](http
 
 ```
 ❯ image-creator --help
-usage: image-creator [-h] [--build-dir BUILD_DIR] [-C] [-K] [-X] [-T CONCURRENCY] [-D] [-V] CONFIG_SRC OUTPUT
+usage: image-creator [-h] [--build-dir BUILD_DIR] [--cache-dir CACHE_DIR] [-C] [-K] [-X] [-T CONCURRENCY] [-D] [-V] CONFIG_SRC OUTPUT
 
-create an Offspot Image from a config
+Create an Offspot Image from a config file
 
 positional arguments:
   CONFIG_SRC            Offspot Config YAML file path or URL
@@ -24,7 +24,12 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   --build-dir BUILD_DIR
-                        Directory to store temporary files in, like files that needs to be extracted. Defaults to some place within /tmp
+                        Directory to store temporary files in, like files that needs to be extracted. Defaults to some place within
+                        /var/folders/p3/58pln35d7y15wpvvl49q3xpm0000gn/T
+  --cache-dir CACHE_DIR
+                        Directory to use as a download cache. Should a remote file be present in the cache, it is fetched from there instead
+                        of being downloaded. Files matching the cache policy are stored to the cache once downloaded. Cache Policy can be
+                        configured in CACHE_DIR/policy.yaml
   -C, --check           Only check inputs, URLs and sizes. Don't download/create image.
   -K, --keep            [DEBUG] Don't remove output image if creation failed
   -X, --overwrite       Don't fail on existing output image: remove instead
@@ -33,6 +38,8 @@ options:
                         `1` to disable concurrency.
   -D, --debug
   -V, --version         show program's version number and exit
+
+See https://github.com/offspot/image-creator for config and cache-policy format
 ```
 
 
@@ -40,21 +47,23 @@ options:
 
 Image configuration is done through a YAML file which must match the following format. Only `base` is required.
 
-
-
-| Member           | Kind           | Function                                                                                                                                                           |
-|------------------|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `base`           | `string`       | Version ([official releases](https://drive.offspot.it/base/)) or URL to a base-image file. Accepts `file://` URLs. Accepts lzma encoded images using `.xz` suffix  |
-| `output.size`    | `string`/`int` | Requested size of output image. Accepts `auto` for an power-of-2 sized that can fit the content (⚠️ TBI)                                                           |
-| `oci_images`     | `string[]`     | List of **specific** OCI Image names. Prefer ghcr.io if possible. [Format](https://github.com/opencontainers/.github/blob/master/docs/docs/introduction/digests.md)|
-| `files`          | `file[]`       | List of files to include on the data partition. See below. One of `url` or `content` must be present                                                               |
-| `files[].url`    | `string`       | URL to download file from                                                                                                                                          |
-| `files[].to`     | `string`       | [required] Path to store file at. Must be a descendent of `/data`                                                                                                  |
-| `files[].content`| `string`       | Text content of the file to write. Replaces `url` if present                                                                                                       |
-| `files[].via`    | `string`       | For `url`-based files, transformation to apply on downloaded file: `direct` (default): simple download, `bztar`, `gztar`, `tar`, `xztar`, `zip` to expand archives |
-| `files[].size`   | `string`/`int` | **Only for `untar`/`unzip`** should file be compressed. Specify expanded size. Assumes File-size (uncompressed) if not specified. ⚠️ Fails if lower than file size |
-| `write_config`   | `bool`         | Whether to write this file to `/data/conf/image.yaml`                                                                                                              |
-| `offspot`        | `dict`         | [runtime-config](https://github.com/offspot/runtime-config) configuration. Will be parsed and dumped to `/boot/offspot.yaml`                                       |
+| Member             | Kind           | Function                                                                                                                                                           |
+|--------------------|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `base`             | `string`       | Version ([official releases](https://drive.offspot.it/base/)) or URL to a base-image file. Accepts `file://` URLs. Accepts lzma encoded images using `.xz` suffix  |
+| `output.size`      | `string`/`int` | Requested size of output image. Accepts `auto` for an power-of-2 sized that can fit the content (⚠️ TBI)                                                           |
+| `oci_images`       | `image[]`      | List of  OCI Image                                                                                                                                                 |
+| **`image[].id`**   | `string`       | **specific** OCI Image name. Prefer ghcr.io if possible. [Format](https://github.com/opencontainers/.github/blob/master/docs/docs/introduction/digests.md)         |
+| `image[].url`      | `string`       | Optional URL to the exported tar file of the image. Downloaded from registry if not present                                                                        |
+| `image[].filesize` | `int`          | Size in bytes of the exported tar file of the image                                                                                                                |
+| `image[].fullsize` | `int`          | Size in bytes of the extracted tar file of the image. See Get OCI Image Sizes below                                                                                |
+| `files`            | `file[]`       | List of files to include on the data partition. See below. One of `url` or `content` must be present                                                               |
+| `files[].url`      | `string`       | URL to download file from                                                                                                                                          |
+| `files[].to`       | `string`       | [required] Path to store file at. Must be a descendent of `/data`                                                                                                  |
+| `files[].content`  | `string`       | Text content of the file to write. Replaces `url` if present                                                                                                       |
+| `files[].via`      | `string`       | For `url`-based files, transformation to apply on downloaded file: `direct` (default): simple download, `bztar`, `gztar`, `tar`, `xztar`, `zip` to expand archives |
+| `files[].size`     | `string`/`int` | **Only for `untar`/`unzip`** should file be compressed. Specify expanded size. Assumes File-size (uncompressed) if not specified. ⚠️ Fails if lower than file size |
+| `write_config`     | `bool`         | Whether to write this file to `/data/conf/image.yaml`                                                                                                              |
+| `offspot`          | `dict`         | [runtime-config](https://github.com/offspot/runtime-config) configuration. Will be parsed and dumped to `/boot/offspot.yaml`                                       |
 
 ### Sample
 
@@ -91,4 +100,102 @@ offspot:
         ports:
           - "80:80"
 
+```
+
+### Get OCI Images Sizes
+
+`image-creator` needs to know about all content's sizes in order to create the image. This includes the OCI Image filesize and fullsize (once extracted on disk). To simplify getting those values, you can use a script that will download the image and extract it to compute the necessary sizes and print the required information in the appropriate format for copy-pasting.
+
+```sh
+curl -o ~/bin/get-oci-sizes https://raw.githubusercontent.com/offspot/image-creator/main/get-oci-sizes.py && chmod +x ~/bin/get-oci-sizes
+```
+
+**Usage:**
+
+```sh
+❯ ./get-oci-sizes.py ghcr.io/offspot/base-httpd:dev
+Downloading ghcr.io/offspot/base-httpd:dev using docker-export
+oci_images:
+  - id: ghcr.io/offspot/base-httpd:dev
+    # url: PREFIX/ghcr.io_offspot_base-httpd:dev.tar
+    filesize: 5980160  # 5.70MiB
+    fullsize: 5944584  # 5.67MiB
+❯ ./get-oci-sizes.py caddy-2.6.1-alpine_armv6.tar
+oci_images:
+  - id: caddy-2.6.1-alpine_armv6  # !fixup
+    # url: PREFIX/caddy-2.6.1-alpine_armv6.tar
+    filesize: 43847680  # 41.82MiB
+    fullsize: 43803832  # 41.77MiB
+```
+
+## Cache Policy
+
+As `image-creator` mostly moves content from remote locations into an image file, it features a configurable *Cache* so that users creating multiple images have an option to download-once and reuse.
+
+The cache is optional and set to a particular directory using `--cache-dir` option. The cache is flexible and configurable via a `policy.yaml` file inside of it. A default cache-policy is created if not present.
+
+_Only define the properties you want_. Everything's optionnal. Sub-levels are bound by upper level. If you define a filter, a **`pattern`** is mandatory.
+
+| Key                      | Kind       | Default   | Function                                                                                      |
+|--------------------------|------------|-----------|-----------------------------------------------------------------------------------------------|
+| `enabled`                | `bool`     | `true`    | Use to disable the cache completely.                                                          |
+| `max_size`               | `size`     | `10GiB`   | Overalll maximum size for cache. `0` disables                                                 |
+| `max_age`                | `duration` |           | Duration after which an entry should be evicted (from added-date)                             |
+| `max_num`                | `int`      |           | Max number of items to keep in cache. `0` disables                                            |
+| `eviction`               | `string`   | `lru`     | Main eviction Strategy. One of `oldest`, `newest`, `largest`, `smallest`, `lru`               |
+| `oci_images`             | `dict`     |           | OCI-Images specific cache configuration                                                       |
+| `oci_images.enabled`     | `bool`     | `true`    | If `false`, no OCI Image is cached.                                                           |
+| `oci_images.max_size`    | `size`     |           | Size of the OCI-Images cache. Must fit witin main cache size                                  |
+| `oci_images.max_age`     | `duration` |           | Duration after which an OCI Image should be evicted                                           |
+| `oci_images.max_num`     | `int`      |           | Max number of OCI-Images to keep in cache.                                                    |
+| `oci_images.eviction`    | `string`   | `lru`     | OCI Images Eviction Strategy                                                                  |
+| `oci_images.filters`     | `list`     |           | Patterns to override config for. First matched is applied. Options applies to all matched     |
+| **`.filters[].pattern`** | `string`   |           | Regexp to match OCI Image identifier. ex: `\/kiwix\/`                                         |
+| `.filters[].max_size`    | `size`     |           | Max total size of cache for entries of this pattern                                           |
+| `.filters[].max_age`     | `duration` |           | Duration after which entries of this pattern should be evicted                                |
+| `.filters[].max_num`     | `int`      |           | Max number of cache entries for this pattern                                                  |
+| `.filters[].eviction`    | `string`   | `lru`     | Eviction strategy for cache entries of this pattern                                           |
+| `.filters[].ignore`      | `bool`     | `false`   | Don't cache entries of this pattern                                                           |
+| `files`                  | `dict`     |           | Files (content and base image) specific cache configuration                                   |
+| `files.enabled`          | `bool`     | `true`    | If `false`, no file/base is cached.                                                           |
+| `files.max_size`         | `size`     |           | Size of the Files/base cache. Must fit witin main cache size                                  |
+| `files.max_age`          | `duration` |           | Duration after which Files/base should be evicted                                             |
+| `files.max_num`          | `int`      |           | Max number of files/base to keep in cache.                                                    |
+| `files.eviction`         | `string`   | `lru`     | Files Eviction Strategy                                                                       |
+| `files.filters`          | `list`     |           | Patterns to override config for. First matched is applied. Options applies to all matched     |
+| **`.filters[].pattern`** | `string`   |           | Regexp to match Files URLs. ex: `https?\/\/download\.kiwix\.org\/zim\/`                       |
+| `.filters[].max_size`    | `size`     |           | Max total size of cache for entries of this pattern                                           |
+| `.filters[].max_age`     | `duration` |           | Duration after which entries of this pattern should be evicted                                |
+| `.filters[].max_num`     | `int`      |           | Max number of cache entries for this pattern                                                  |
+| `.filters[].eviction`    | `string`   |           | Eviction strategy for cache entries of this pattern                                           |
+| `.filters[].ignore`      | `bool`     | `false`   | Don't cache entries of this pattern                                                           |
+
+- `size` type is a parse-able file size string (`1G`, `2.4GiB`) or `0` string.
+- `duration` type is a parse-able timespan string (`30d` `4w` `1y`) or `0` string.
+
+### Default Policy
+
+```yaml
+---
+enabled: true
+max_size: 10GiB
+eviction: lru
+oci_images:
+  enabled: true
+  eviction: lru
+files:
+  enabled: true
+  eviction: lru
+```
+
+### Sample Policy
+
+```yaml
+---
+enabled: true
+max_size: 0
+oci_images:
+  eviction: oldest
+files:
+  enabled: false
 ```

--- a/get-oci-sizes.py
+++ b/get-oci-sizes.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+""" Outputs the sizes of an OCI Image for use in image.yaml
+
+    Computes the file size of an exported image and its on-disk (extract) sizes
+    either from an image name (as in docker/docker-export) or a tar file
+
+    Dependencies:
+        - docker-export must be present in PATH if not referencing a local file
+
+    Usage:
+
+        get-oci-sizes docker.io/library/caddy:2.6.1-alpine
+        get-oci-sizes docker.io_library_caddy:2.6.1-alpine.tar
+
+
+    Output:
+
+        oci_images:
+          - ident: docker.io/library/caddy:2.6.1-alpine
+            # url: PREFIX/docker.io_library_caddy:2.6.1-alpine.tar
+            filesize: 47206400  # 45.02MiB
+            fullsize: 47156908  # 44.97MiB
+"""
+
+import pathlib
+import subprocess
+import sys
+import tarfile
+import tempfile
+from typing import Tuple
+
+
+def get_dirsize(fpath: pathlib.Path) -> int:
+    """size in bytes of a local directory"""
+    if not fpath.exists():
+        raise FileNotFoundError(fpath)
+    if fpath.is_file():
+        raise IOError(f"{fpath} is a file")
+    return sum(f.stat().st_size for f in fpath.rglob("**/*") if f.is_file())
+
+
+def human(size: int) -> str:
+    """Human-readable (MiB/GiB) size"""
+    one_mib = 2**20
+    one_gib = 2**30
+    suffix = "GiB" if size >= one_gib else "MiB"
+    denom = one_gib if size >= one_gib else one_mib
+    value = size / denom
+    return f"{value:.2f}{suffix}"
+
+
+def sizes_from_path(fpath: pathlib.Path) -> Tuple[int, int]:
+    """filesize and fullsize from a local tar file"""
+    filesize = fpath.stat().st_size
+
+    temp_dir = tempfile.TemporaryDirectory(
+        prefix=fpath.name, ignore_cleanup_errors=True
+    )
+    temp_dir_path = pathlib.Path(temp_dir.name)
+    with tarfile.open(fpath) as tar:
+        tar.extractall(temp_dir_path)
+
+    fullsize = get_dirsize(temp_dir_path)
+    temp_dir.cleanup()
+    return filesize, fullsize
+
+
+def print_from_path(fpath: pathlib.Path, name: str = None):
+    filesize, fullsize = sizes_from_path(fpath)
+    fuzzy_text = "  # !fixup" if not name else ""
+    name = name if name else fpath.stem
+    print(
+        f"oci_images:\n"
+        f"  - ident: {name}{fuzzy_text}\n"
+        f"    # url: PREFIX/{fpath.name}\n"
+        f"    filesize: {filesize}  # {human(filesize)}\n"
+        f"    fullsize: {fullsize}  # {human(fullsize)}\n"
+    )
+
+
+def download_image(name: str) -> pathlib.Path:
+    """download image to a tar file using docker-export"""
+    fs_name = pathlib.Path(f"{pathlib.Path(name.replace('/', '_'))}.tar")
+    subprocess.run(
+        ["/usr/bin/env", "docker-export", name, str(fs_name)],
+        check=True,
+        capture_output=True,
+    )
+    return fs_name
+
+
+def main(name_or_path: str) -> int:
+    fpath = pathlib.Path(name_or_path)
+
+    if not fpath.exists():
+        image_name = name_or_path
+        print(f"Downloading {name_or_path} using docker-export", file=sys.stderr)
+        fpath = download_image(name_or_path)
+    else:
+        image_name = None
+
+    # not an existing path ; maybe it's an image name
+    if not fpath.exists():
+        print(f"Can't find image file at {fpath}", file=sys.stderr)
+        return 1
+
+    print_from_path(fpath, image_name)
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} PATH")
+        sys.exit(1)
+    sys.exit(main(sys.argv[1]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ cli-ui==0.17.2
 humanfriendly==10.0
 progressbar2==4.2.0
 docker_export==0.4
+xattr==0.10.1

--- a/src/image_creator/cache/manager.py
+++ b/src/image_creator/cache/manager.py
@@ -1,0 +1,525 @@
+import datetime
+import pathlib
+from typing import Iterable, List, Optional, Tuple, Union
+
+from image_creator.cache.policy import Eviction, MainPolicy, Policy
+from image_creator.constants import logger
+from image_creator.inputs import File
+from image_creator.utils.download import get_digest
+from image_creator.utils.misc import (
+    SimpleAttrs,
+    copy_file,
+    format_dt,
+    format_duration,
+    format_size,
+    get_filesize,
+    is_http,
+)
+from image_creator.utils.oci_images import Image, OCIImage, get_image_digest
+
+Item = Union[File, OCIImage]
+
+
+def path_for_item(item: Item) -> pathlib.Path:
+    return path_for_image(item) if isinstance(item, OCIImage) else path_for_file(item)
+
+
+def path_for_image(image: OCIImage) -> pathlib.Path:
+    """cache-relative path for an image archive"""
+    fname = image.oci.name
+    if image.oci.tag:
+        fname += f":{image.oci.tag}"
+    if image.oci.digest:
+        fname += f"@{image.oci.digest}"
+    return (
+        pathlib.Path("images")
+        .joinpath(image.oci.registry)
+        .joinpath(image.oci.repository)
+        .joinpath(fname)
+    )
+
+
+def path_for_file(file: File) -> pathlib.Path:
+    """cache-relative path for a File"""
+    # fake a filepath should there be none
+    if not file.url.path or file.url.path == "/":
+        path = pathlib.Path("/__ROOT__")
+    else:
+        path = pathlib.Path(file.url.path).resolve()
+
+    # add params/query/fragment to basename to ensure uniqueness
+    fname = path.parts[-1]
+    if file.url.params:
+        fname += f";{file.url.params}"
+    if file.url.query:
+        fname += f"?{file.url.query}"
+    if file.url.fragment:
+        fname += f"#{file.url.fragment}"
+
+    return (
+        pathlib.Path("files")
+        .joinpath(file.url.scheme)
+        .joinpath(file.url.netloc)
+        # excluding last part (basename) and first (leading slash)
+        .joinpath(*path.parts[1:-1])
+        .joinpath(fname)
+    )
+
+
+def file_is_entry(fpath: pathlib.Path) -> bool:
+    """whether this file looks like a CacheEntry (has source metatada)"""
+    return "digest" in SimpleAttrs(fpath)
+
+
+def digest_for_item(item: Item) -> str:
+    return (
+        get_image_digest(item.oci)
+        if isinstance(item, OCIImage)
+        else get_digest(item.source)
+    )
+
+
+def sort_for(eviction: str, iterable: Iterable):
+    key, reverse = {
+        Eviction.oldest: ("added_on", False),
+        Eviction.newest: ("added_on", True),
+        Eviction.largest: ("size", False),
+        Eviction.smallest: ("size", True),
+        Eviction.lru: ("last_used_on", True),
+    }[eviction]
+    return sorted(iterable, key=lambda item: getattr(item, key), reverse=reverse)
+
+
+class CacheEntry:
+    def __init__(self, fpath):
+        self.fpath = fpath
+        self.size = get_filesize(self.fpath)
+        metadata = SimpleAttrs(self.fpath)
+        self.added_on = datetime.datetime.fromisoformat(metadata["added_on"])
+        self.last_used_on = datetime.datetime.fromisoformat(metadata["last_used_on"])
+        self.nb_used = int(metadata["nb_used"])
+        self.kind, self.source = metadata["source"].split(":", 1)
+        self.digest = metadata["digest"]
+
+    def __repr__(self):
+        return f"{type(self).__name__}(fpath={self.fpath}, self.source={self.source})"
+
+    def get_remote_digest(self) -> str:
+        """retrieve remote source digest"""
+        if self.kind == "image":
+            return get_image_digest(Image.parse(self.source))
+        return get_digest(self.source)
+
+    @property
+    def is_outdated(self):
+        r"""whether remote resource got updated (has different digest)
+
+        /!\ digest-less URLs are considered outdated, always"""
+        if not self.digest:
+            return True
+        try:
+            remote = self.get_remote_digest()
+        except Exception:
+            logger.exception("faild to retrieve remote digest")
+            return False
+        return not remote or remote != self.digest
+
+    def mark_usage(self, num: int = 1):
+        metadata = SimpleAttrs(self.fpath)
+        metadata["nb_used"] = str(self.nb_used + num)
+        metadata["last_used_on"] = datetime.datetime.utcnow().isoformat()
+
+    __iadd__ = mark_usage
+
+    def __int__(self) -> int:
+        return self.nb_used
+
+
+class CacheCandidate(CacheEntry):
+    def __init__(self, item: Item, added_on: Optional[datetime.datetime] = None):
+        self.kind = item.kind
+        self.source = item.source
+        self.size = item.size
+        self.fpath = path_for_item(item)
+        self.digest = digest_for_item(item)
+        self.nb_used = 0
+        self.added_on = self.last_used_on = added_on or datetime.datetime.utcnow()
+
+
+def get_eviction_for(  # noqa: C901
+    entries: List[CacheEntry], policy: Policy
+) -> List[Tuple[CacheEntry, str]]:
+    """list of (entry, reason) from entries that are expired or outdated"""
+    if not policy.enabled:
+        return []
+
+    evictions = []
+
+    total_num = 0
+    total_size = 0
+
+    if hasattr(policy, "filters"):
+        for filter_ in policy.filters:
+            filter_num = 0
+            filter_size = 0
+
+            for entry in sort_for(filter_.eviction, entries):
+                # dont look at this filter policy if entry doesnt match
+                if not filter_.match(entry.source):
+                    continue
+
+                # if ignore is set, we should not cache at all
+                if filter_.ignore:
+                    evictions.append((entry, f"ignored pattern {filter_.pattern}"))
+                    continue
+
+                if filter_.max_age_dt and entry.added_on < filter_.max_age_dt:
+                    evictions.append(
+                        (
+                            entry,
+                            "Too old for filter max_age "
+                            f"({format_duration(filter_.max_age)})",
+                        )
+                    )
+                    continue
+
+                if filter_.max_size and filter_size + entry.size > filter_.max_size:
+                    evictions.append(
+                        (
+                            entry,
+                            "Would exceed filter max_size "
+                            f"({format_size(filter_.max_size)})",
+                        )
+                    )
+                    continue
+
+                if filter_.max_num and filter_num + 1 > filter_.max_num:
+                    evictions.append(
+                        (entry, f"Would exceed filter max_num ({filter_.max_num})")
+                    )
+                    continue
+
+                filter_size += entry.size
+                filter_num += 1
+
+    # applying policy-level boundaries
+    for entry in sort_for(policy.eviction, entries):
+        if entry.kind == "file" and not is_http(entry.source):
+            evictions.append((entry, "Source protocol not cacheable"))
+            continue
+
+        if policy.max_age_dt and entry.added_on < policy.max_age_dt:
+            evictions.append(
+                (
+                    entry,
+                    f"Too old for {type(policy).__name__} max_age "
+                    f"({format_duration(policy.max_age)})",
+                )
+            )
+            continue
+
+        if policy.max_size and total_size + entry.size > policy.max_size:
+            evictions.append(
+                (
+                    entry,
+                    f"Would exceed {type(policy).__name__} max_size "
+                    f"({format_size(policy.max_size)})",
+                )
+            )
+            continue
+
+        if policy.max_num and total_num + 1 > policy.max_num:
+            evictions.append(
+                (
+                    entry,
+                    f"Would exceed {type(policy).__name__} max_num "
+                    f"({policy.max_num})",
+                )
+            )
+            continue
+
+        total_size += entry.size
+        total_num += 1
+
+    return evictions
+
+
+class CacheManager(dict):
+    def __init__(self, root: pathlib.Path, policy: MainPolicy, *args, **kwargs):
+        # cache_dir
+        root.mkdir(parents=True, exist_ok=True)
+        self.root = root
+        self.ref_date = datetime.datetime.utcnow()
+
+        # policy reference
+        self.policy = policy
+
+        # cached (ahah) list of entries seen in the cache
+        self.entries = {}
+        # whether cache_dir has been walked-through or not
+        self.discovered = False
+        # whether cache eviction have been applied or not
+        self.applied = False
+
+        # list of not-in-cache yet candidates
+        self.candidates = {}
+        # whether candidates have been considered (applied) or not
+        self.considered = False
+
+    def walk(self):
+        """walk through filesystem to discover cache content"""
+        if not self.policy.enabled:
+            return
+
+        entries = {}
+        for fpath in self.root.rglob("*"):
+            if not fpath.is_file() or fpath == self.root.joinpath("policy.yaml"):
+                continue
+            if not file_is_entry(fpath):
+                continue
+            entries[fpath.relative_to(self.root)] = CacheEntry(fpath)
+        self.entries = entries
+        self.discovered = True
+
+    @property
+    def size(self) -> int:
+        """total size of cache"""
+        if not self.discovered:
+            self.walk()
+        return sum([entry.size for entry in self.entries.values()])
+
+    def get(self, item: Item) -> CacheEntry:
+        """CacheEntry for Item"""
+        if not self.discovered:
+            self.walk()
+        return self.entries[path_for_item(item)]
+
+    __getitem__ = get
+
+    def in_cache(self, item: Item, check_outdacy: Optional[bool] = False) -> bool:
+        """whether there is a CacheEntry for this item in cache"""
+        if not self.discovered:
+            self.walk()
+        present = path_for_item(item) in self.entries.keys()
+        if not present:
+            return False
+
+        if check_outdacy:
+            if self[item].is_outdated:
+                self.evict(self[item], "Found outdated")
+                return False
+        return present
+
+    __contains__ = in_cache
+
+    def __len__(self):
+        if not self.discovered:
+            self.walk()
+        return len(self.entries)
+
+    def __iter__(self):
+        return iter(list(self.entries.values()))
+
+    def introduce(self, item: Item, src_path: pathlib.Path) -> bool:
+        """whether item (File or OCI Image) was successfuly introduced to cache"""
+
+        if not self.should_cache(item):
+            return False
+
+        relpath = path_for_item(item)
+        entry = self.candidates[relpath]
+        fpath = self.root.joinpath(entry.fpath)
+
+        metadata = dict()
+        metadata["added_on"] = entry.added_on.isoformat()
+        metadata["last_used_on"] = entry.last_used_on.isoformat()
+        metadata["nb_used"] = "1"
+        metadata["source"] = f"{entry.kind}:{entry.source}"
+        metadata["digest"] = digest_for_item(item)
+
+        try:
+            copy_file(src_path, fpath)
+        except Exception as exc:
+            logger.exception(exc)
+            return False
+        try:
+            attrs = SimpleAttrs(fpath)
+            attrs.clear()
+            for attr, value in metadata.items():
+                attrs[attr] = value
+        except Exception as exc:
+            logger.exception(exc)
+            try:
+                fpath.unlink()
+            except Exception as exc2:
+                logger.exception(exc2)
+            return False
+
+        # move from candidates to entries
+        self.entries[relpath] = entry
+        del self.candidates[relpath]
+
+        return True
+
+    def evict(self, entry: CacheEntry, reason: str) -> bool:
+        """whether entry was successfuly evicted from cache"""
+        if not self.policy.enabled:
+            return False
+
+        try:
+            entry.fpath.unlink()
+        except Exception as exc:
+            logger.exception(exc)
+            return False
+
+        del self.entries[entry.fpath.relative_to(self.root)]
+
+        return True
+
+    def add_candidate(self, item: Item):
+        if not self.policy.enabled:
+            return
+
+        if not self.applied:
+            self.apply()
+
+        self.candidates[path_for_item(item)] = CacheCandidate(
+            item, added_on=self.ref_date
+        )
+
+    def should_cache(self, item: Item) -> bool:
+        """whether cache application for entry was accepted"""
+        if not self.policy.enabled:
+            return False
+
+        # wouldn't make sense to check this without actualy go through screening
+        if not self.considered:
+            self.apply_candidates()
+
+        return path_for_item(item) in self.candidates.keys()
+
+    def get_eviction_for(
+        self, entries: List[CacheEntry]
+    ) -> List[Tuple[CacheEntry, str]]:
+        if not self.policy.enabled:
+            return []
+
+        evictions = get_eviction_for(
+            [entry for entry in entries if entry.kind == "image"],
+            self.policy.oci_images,
+        )
+        entries = [entry for entry in entries if entry not in evictions]
+        evictions += get_eviction_for(
+            [entry for entry in entries if entry.kind == "file"], self.policy.files
+        )
+        entries = [entry for entry in entries if entry not in evictions]
+        evictions += get_eviction_for(entries, self.policy)
+
+        return list(set(evictions))
+
+    def dry_apply(self) -> List[Tuple[CacheEntry, str]]:
+        """list of (entry, reason) entries from cache that needs eviction"""
+        return self.get_eviction_for(list(self.entries.values()))
+
+    def apply(self) -> List[Tuple[CacheEntry, str, bool]]:
+        """(entry, reason, success) list of evictions for applying policy"""
+        if not self.policy.enabled:
+            return
+
+        evicted = []
+        for entry, reason in self.dry_apply():
+            evicted.append((entry, reason, self.evict(entry, reason)))
+
+        self.applied = True
+
+        return evicted
+
+    def evict_outdated(self) -> List[Tuple[CacheEntry, str, bool]]:
+        """Check all Cache entries for remote updates"""
+        evicted = []
+        reason = "outdated"
+        for entry in list(self.entries.values()):
+            if entry.is_outdated:
+                evicted.append((entry, reason, self.evict(entry, reason)))
+        return evicted
+
+    def apply_candidates(self):
+        """run algo through entries + candidates, removing candidates that wont stay"""
+
+        for entry, reason in self.get_eviction_for(
+            list(self.entries.values()) + list(self.candidates.values())
+        ):
+            if entry in self.entries.values():
+                self.evict(entry, f"{reason} [apply-candidates]")
+            else:
+                del self.candidates[entry.fpath]
+
+        self.considered = True
+
+    def print(self, with_evictions: Optional[bool] = False):
+        """print content of cache"""
+        if not self.discovered:
+            self.walk()
+
+        logger.message("")
+
+        if not self.entries:
+            logger.message("Cache is empty.")
+        else:
+            sorted_e = sorted(self.entries.values(), key=lambda e: e.added_on)
+            oldest, newest = sorted_e[0], sorted_e[-1]
+            # oldest, newest = datetime.datetime.utcnow(), datetime.datetime.utcnow()
+
+            logger.table(
+                headers=["Size", "Entries", "Oldest", "Newest"],
+                data=[
+                    [
+                        (format_size(self.size),),
+                        (str(len(self)),),
+                        (format_dt(oldest.added_on),),
+                        (format_dt(newest.added_on),),
+                    ],
+                ],
+            )
+            logger.message("")
+
+            evictions = [e for e, _ in self.dry_apply()] if with_evictions else []
+
+            def style_for(entry: CacheEntry):
+                if not with_evictions or entry not in evictions:
+                    return logger.ui.reset
+                return logger.ui.red
+
+            logger.table(
+                headers=["Size", "Added On", "Nb. Used", "Last Used", "Source", "Path"],
+                data=[
+                    [
+                        (
+                            style_for(entry),
+                            format_size(entry.size),
+                        ),
+                        (
+                            style_for(entry),
+                            format_dt(entry.added_on),
+                        ),
+                        (
+                            style_for(entry),
+                            str(entry.nb_used),
+                        ),
+                        (
+                            style_for(entry),
+                            format_dt(entry.last_used_on),
+                        ),
+                        (
+                            style_for(entry),
+                            entry.source,
+                        ),
+                        (
+                            style_for(entry),
+                            entry.fpath.relative_to(self.root),
+                        ),
+                    ]
+                    for entry in sorted(self, key=lambda e: e.added_on)
+                ],
+            )
+        logger.message("")

--- a/src/image_creator/cache/policy.py
+++ b/src/image_creator/cache/policy.py
@@ -1,0 +1,242 @@
+import datetime
+import re
+from dataclasses import MISSING, dataclass, field
+from typing import Iterable, List, Optional, Union
+
+try:
+    from yaml import CLoader as Loader
+    from yaml import load as yaml_load
+except ImportError:
+    # we don't NEED cython ext but it's faster so use it if avail.
+    from yaml import Loader, load as yaml_load
+
+from image_creator.utils.misc import (
+    enforce_types,
+    is_dict,
+    is_list_of_dict,
+    parse_duration,
+    parse_size,
+)
+
+
+@dataclass(init=False)
+class Eviction:
+    oldest: str = "oldest"
+    newest: str = "newest"
+    largest: str = "largest"
+    smallest: str = "smallest"
+    lru: str = "lru"
+
+    @classmethod
+    def default(cls) -> str:
+        return cls.lru
+
+    @classmethod
+    def all(cls) -> Iterable:
+        return tuple(cls.__dataclass_fields__.keys())
+
+
+class Policy:
+    ...
+
+
+@dataclass(kw_only=True)
+class CommonParamsMixin(Policy):
+    max_size: Optional[Union[int, str]] = None
+    max_age: Optional[Union[int, str]] = None
+    max_num: Optional[int] = None
+    eviction: str = Eviction.default()
+
+    @property
+    def checkable_fields(self):
+        return ("max_size", "max_age", "max_num")
+
+    @property
+    def max_age_dt(self) -> Optional[datetime.datetime]:
+        """datetime that is max_age in the past"""
+        if not self.max_age:
+            return None
+        return datetime.datetime.utcnow() - datetime.timedelta(seconds=self.max_age)
+
+    def parse_max_size(self):
+        if self.max_size is None or (
+            isinstance(self.max_size, int) and self.max_size > 0
+        ):
+            return
+        elif self.max_size == 0:
+            self.max_size = None
+            return
+        elif isinstance(self.max_size, int):
+            raise ValueError(
+                f"Invalid negative value `{self.max_size}` "
+                f"for {type(self).__name__}.max_size"
+            )
+        try:
+            self.max_size = parse_size(self.max_size)
+        except Exception as exc:
+            raise ValueError(
+                f"Unable to parse `{self.max_size}` into size "
+                f"for {type(self).__name__}.max_size ({exc})"
+            )
+
+    def parse_max_age(self):
+        if self.max_age is None or (isinstance(self.max_age, int) and self.max_age > 0):
+            return
+        elif self.max_age == 0:
+            self.max_age = None
+            return
+        elif isinstance(self.max_age, int):
+            raise ValueError(
+                f"Invalid negative value `{self.max_age}` "
+                f"for {type(self).__name__}.max_age"
+            )
+        try:
+            self.max_age = parse_duration(self.max_age)
+        except Exception as exc:
+            raise ValueError(
+                f"Unable to parse `{self.max_age}` into duration "
+                f"for {type(self).__name__}.max_age ({exc})"
+            )
+
+    def enforce_eviction(self):
+        if self.eviction not in Eviction.all():
+            raise ValueError(
+                f"Unexpected value `{self.eviction}` "
+                f"for {type(self).__name__}.eviction."
+                f"Accepts: {', '.join(Eviction.all())}"
+            )
+
+    def __post_init__(self):
+        self.enforce_eviction()
+        self.parse_max_size()
+        self.parse_max_age()
+
+
+@enforce_types
+@dataclass
+class SubPolicyFilter(CommonParamsMixin):
+    pattern: str
+    ignore: Optional[bool] = False
+
+    def match(self, value: str):
+        return re.match(self.pattern, value, re.IGNORECASE)
+
+
+@dataclass()
+class SubPolicy(CommonParamsMixin):
+    enabled: Optional[bool] = True
+    filters: List[SubPolicyFilter] = field(default_factory=list)
+
+    def __post_init__(self, *args, **kwargs):
+        super().__post_init__(*args, **kwargs)
+        self.check()
+
+    def check(self):
+        for idx, filter_ in enumerate(self.filters):
+            for value in self.checkable_fields:
+                if (
+                    getattr(filter_, value)
+                    and getattr(self, value)
+                    and getattr(filter_, value) > getattr(self, value)
+                ):
+                    raise ValueError(
+                        f"{type(filter_).__name__}[{idx}].{value} "
+                        f"({getattr(filter_, value)}) "
+                        f"exceeds {type(self).__name__}.{value} "
+                        f"({getattr(self, value)})"
+                    )
+
+
+@enforce_types
+class OCIImagePolicy(SubPolicy):
+    ...
+
+
+@enforce_types
+class FilesPolicy(SubPolicy):
+    ...
+
+
+@enforce_types
+@dataclass
+class MainPolicy(CommonParamsMixin):
+    oci_images: Optional[OCIImagePolicy] = field(default_factory=OCIImagePolicy)
+    files: Optional[FilesPolicy] = field(default_factory=FilesPolicy)
+    enabled: Optional[bool] = True
+
+    def __post_init__(self, *args, **kwargs):
+        super().__post_init__(*args, **kwargs)
+        self.check()
+
+    @classmethod
+    def defaults(cls):
+        """A Policy with default values"""
+        return cls(enabled=True, max_size="10GiB", eviction=Eviction.lru)
+
+    @classmethod
+    def disabled(cls):
+        """A cache-less Policy"""
+        return cls(enabled=False)
+
+    @classmethod
+    def sub_names(cls):
+        """names of fields referencing SubPolicies"""
+        return [
+            name
+            for name, field in cls.__dataclass_fields__.items()
+            if field.default_factory != MISSING
+            and SubPolicy in field.default_factory.mro()
+        ]
+
+    @classmethod
+    def read_from(cls, text: str):
+        """Policy from a YAML string config"""
+
+        # parse YAML (Dict) will be our input to Policy()
+        payload = yaml_load(text, Loader=Loader)
+
+        # Subpolicies have subclasses for human-friendlyness
+        _sub_policy_map = {"oci_images": OCIImagePolicy, "files": FilesPolicy}
+
+        # build SubPolicies first (args of the main Policy)
+        for name in cls.sub_names():
+            sub_policy_cls = _sub_policy_map.get(name, SubPolicy)
+
+            # remove he key from payload ; we'll replace it with actual SubPolocy
+            subload = payload.pop(name, None)
+
+            # fail early if SubPolicy is not well formatted
+            if not is_dict(subload, True):
+                raise ValueError(f"Unexpected type for Policy.{name}: {type(subload)}")
+
+            # remove filters from (sub)payload ; we'll replace with actual FilterPolicy
+            filters = subload.pop("filters", [])
+            if not is_list_of_dict(filters):
+                raise ValueError(
+                    f"Unexpected type for Policy.{name}.filters: {type(filters)}"
+                )
+
+            # create FilterPolicies (will fail in case of errors)
+            subload["filters"] = [SubPolicyFilter(**subfilter) for subfilter in filters]
+
+            # now create the SubPolicy with our filters, storing on main payload
+            payload[name] = sub_policy_cls(**subload)
+
+        # ready to create the actual main Policy
+        return cls(**payload)
+
+    def check(self):
+        for subname in self.sub_names():
+            sub_policy = getattr(self, subname)
+            for value in self.checkable_fields:
+                if (
+                    getattr(sub_policy, value)
+                    and getattr(self, value)
+                    and getattr(sub_policy, value) > getattr(self, value)
+                ):
+                    raise ValueError(
+                        f"{type(sub_policy).__name__}.{value} "
+                        f"({getattr(sub_policy, value)}) "
+                        f"exceeds {type(self).__name__}.{value} "
+                        f"({getattr(self, value)})"
+                    )

--- a/src/image_creator/constants.py
+++ b/src/image_creator/constants.py
@@ -1,6 +1,5 @@
 import logging
 import pathlib
-import re
 import sys
 import tempfile
 import urllib.parse
@@ -9,6 +8,7 @@ from typing import Union
 
 from image_creator import __version__ as vers
 from image_creator.logger import Logger
+from image_creator.utils.misc import is_http
 
 # where will data partition be monted on final device.
 # used as reference for destinations in config file and in the UI
@@ -33,13 +33,16 @@ class Options:
     CONFIG_SRC: str
     OUTPUT: str
     BUILD_DIR: str
+    CACHE_DIR: str
 
+    show_cache: bool
     check_only: bool
     debug: bool
 
     config_path: pathlib.Path = None
     output_path: pathlib.Path = None
     build_dir: pathlib.Path = None
+    cache_dir: pathlib.Path = None
 
     keep_failed: bool
     overwrite: bool
@@ -49,7 +52,7 @@ class Options:
     logger: Logger = Logger()
 
     def __post_init__(self):
-        if re.match(r"^https?://", self.CONFIG_SRC):
+        if is_http(self.CONFIG_SRC):
             self.config_url = urllib.parse.urlparse(self.CONFIG_SRC)
         else:
             self.config_path = pathlib.Path(self.CONFIG_SRC).expanduser().resolve()
@@ -68,6 +71,9 @@ class Options:
         self.build_dir = (
             pathlib.Path(self.BUILD_DIR or self.__build_dir.name).expanduser().resolve()
         )
+
+        if self.CACHE_DIR:
+            self.cache_dir = pathlib.Path(self.CACHE_DIR).expanduser().resolve()
 
     @property
     def version(self):

--- a/src/image_creator/creator.py
+++ b/src/image_creator/creator.py
@@ -13,6 +13,10 @@ class ImageCreator:
         atexit.register(self.halt)
 
     def run(self):
+        if not Global.options.cache_dir:
+            StepMachine.remove_step("ApplyCachePolicy")
+        if not Global.options.show_cache:
+            StepMachine.remove_step("PrintingCache")
         if Global.options.check_only:
             StepMachine.halt_after("ComputeSizes")
 

--- a/src/image_creator/entrypoint.py
+++ b/src/image_creator/entrypoint.py
@@ -11,7 +11,8 @@ def main():
     parser = argparse.ArgumentParser(
         prog="image-creator",
         description="Create an Offspot Image from a config file",
-        epilog="See https://github.com/offspot/image-creator for config format",
+        epilog="See https://github.com/offspot/image-creator "
+        "for config and cache-policy format",
     )
 
     parser.add_argument(
@@ -20,6 +21,22 @@ def main():
         help="Directory to store temporary files in, "
         "like files that needs to be extracted. "
         f"Defaults to some place within {tempfile.gettempdir()}",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        dest="CACHE_DIR",
+        help="Directory to use as a download cache. "
+        "Should a remote file be present in the cache, "
+        "it is fetched from there instead of being downloaded. "
+        "Files matching the cache policy are stored to the cache once downloaded. "
+        "Cache Policy can be configured in CACHE_DIR/policy.yaml",
+    )
+    parser.add_argument(
+        "--show-cache",
+        action="store_true",
+        dest="show_cache",
+        help="Print a summary of the Cache's content. "
+        "Use with --check to query a Cache's status.",
     )
     parser.add_argument(
         "-C",

--- a/src/image_creator/logger.py
+++ b/src/image_creator/logger.py
@@ -2,13 +2,13 @@ import enum
 import logging
 import pathlib
 import traceback
-from typing import Optional
+from typing import Any, Optional, Sequence, Union
 
 import cli_ui as ui
 
 Status = enum.Enum("Status", ["OK", "NOK", "NEUTRAL"])
 Colors = {Status.NEUTRAL: ui.reset, Status.OK: ui.green, Status.NOK: ui.red}
-ui.warn = ui.UnicodeSequence(ui.brown, "⚠️", "/!\\")
+ui.warn = ui.UnicodeSequence(ui.brown, "⚠️", "[!]")
 
 
 class Logger:
@@ -41,6 +41,10 @@ class Logger:
         self.setLevel(level)
 
         self.currently = None
+
+    @property
+    def ui(self):
+        return ui
 
     def setLevel(self, level: int):
         """reset logger's verbose config based on level"""
@@ -89,6 +93,9 @@ class Logger:
 
     def fatal(self, text: str):
         self.critical(text)
+
+    def table(self, data: Any, headers: Union[str, Sequence[str]]):
+        ui.info_table(data=data, headers=headers)
 
     @property
     def with_progress(self) -> bool:

--- a/src/image_creator/logger.py
+++ b/src/image_creator/logger.py
@@ -105,13 +105,7 @@ class Logger:
     @property
     def indent_level(self):
         """standard indentation level based on current ~position"""
-        match self.currently:
-            case "step":
-                return 3
-            case "task":
-                return 6
-            case _:
-                return 0
+        return {"step": 3, "task": 6}.get(self.currently, 0)
 
     def mark_as(self, what: str):
         """set new ~position of the logger: step or task"""

--- a/src/image_creator/steps/base.py
+++ b/src/image_creator/steps/base.py
@@ -1,33 +1,77 @@
-import shutil
+import pathlib
 from typing import Any, Dict
 
 from image_creator.constants import logger
 from image_creator.inputs import File
 from image_creator.steps import Step
 from image_creator.utils.download import download_file
-from image_creator.utils.misc import extract_xz_image, format_size, get_filesize
+from image_creator.utils.misc import (
+    copy_file,
+    extract_xz_image,
+    format_size,
+    get_filesize,
+)
 
 
 class DownloadImage(Step):
     name = "Fetching base image"
 
     def run(self, payload: Dict[str, Any]) -> int:
-        """whether system requirements are satisfied"""
-        base_file = payload["config"].base
+        # we need to extract this into the actual target
+        if payload["config"].base.getpath().suffix == ".xz":
+            return self.run_compressed(payload["config"].base, payload)
 
-        # no need to download
-        if base_file.is_local:
-            return self.run_local(base_file, payload)
+        return self.run_uncompressed(payload["config"].base, payload)
 
-        # we'll have to download it
-        return self.run_remote(base_file, payload)
+    def run_uncompressed(self, base_file: File, payload: Dict[str, Any]) -> int:
+        target = payload["options"].output_path
 
-    def run_remote(self, base_file: File, payload: Dict[str, Any]) -> int:
-        rem_path = base_file.getpath()
+        if base_file not in payload["cache"] and not base_file.is_local:
+            logger.start_task(f"Downloading {base_file.geturl()} into {target}…")
+            try:
+                download_file(base_file.geturl(), target)
+            except Exception as exc:
+                logger.fail_task(str(exc))
+                return 1
+            else:
+                logger.succeed_task(format_size(get_filesize(target)))
+                if payload["cache"].should_cache(base_file):
+                    logger.start_task("Adding Base Image to cache…")
+                    if payload["cache"].introduce(base_file, target):
+                        logger.succeed_task()
+                    else:
+                        logger.fail_task()
 
-        # we'll have to download it to build-dir then extract
-        if rem_path.suffix == ".xz":
-            xz_fpath = payload["options"].build_dir.joinpath(rem_path.name)
+            return 0
+
+        if base_file in payload["cache"]:
+            src_path = payload["cache"][base_file].fpath
+            message = f"Copying from cache… into {target}"
+        else:
+            src_path = base_file.getpath()
+            message = f"Copying {src_path} into {target}…"
+
+        logger.start_task(message)
+        try:
+            copy_file(src_path, target)
+        except Exception as exc:
+            logger.fail_task(str(exc))
+            return 1
+        else:
+            logger.succeed_task(format_size(get_filesize(target)))
+
+        if base_file in payload["cache"]:
+            payload["cache"][base_file] += 1
+
+        return 0
+
+    def run_compressed(self, base_file: File, payload: Dict[str, Any]) -> int:
+        target = payload["options"].output_path
+        xz_fpath = payload["options"].build_dir.joinpath(base_file.getpath().name)
+        remove_xz = False
+
+        # we need to download it first
+        if base_file not in payload["cache"] and not base_file.is_local:
             logger.start_task(f"Downloading {base_file.geturl()} into {xz_fpath}…")
             try:
                 download_file(base_file.geturl(), xz_fpath)
@@ -36,20 +80,43 @@ class DownloadImage(Step):
                 return 1
             else:
                 logger.succeed_task(format_size(get_filesize(xz_fpath)))
-
-            logger.start_task(
-                f"Extracting {xz_fpath} into {payload['options'].output_path}…"
+                remove_xz = True
+                if payload["cache"].should_cache(base_file):
+                    logger.start_task("Adding Base Image to cache…")
+                    if payload["cache"].introduce(base_file, xz_fpath):
+                        logger.succeed_task()
+                    else:
+                        logger.fail_task()
+        else:
+            xz_fpath = (
+                payload["cache"][base_file].fpath
+                if base_file in payload["cache"]
+                else base_file.getpath()
             )
-            try:
-                extract_xz_image(xz_fpath, payload["options"].output_path)
-            except Exception as exc:
-                logger.fail_task(str(exc))
-                return 1
-            else:
-                logger.succeed_task(
-                    format_size(get_filesize(payload["options"].output_path))
-                )
 
+        return self.extract(base_file, payload, xz_fpath, target, remove_xz)
+
+    def extract(
+        self,
+        base_file,
+        payload: Dict[str, Any],
+        xz_fpath: pathlib.Path,
+        target: pathlib.Path,
+        remove_xz: bool,
+    ) -> int:
+        logger.start_task(f"Extracting {xz_fpath}…")
+        try:
+            extract_xz_image(xz_fpath, target)
+        except Exception as exc:
+            logger.fail_task(str(exc))
+            return 1
+        else:
+            logger.succeed_task(format_size(get_filesize(target)))
+
+        if base_file in payload["cache"]:
+            payload["cache"][base_file] += 1
+
+        if remove_xz:
             logger.start_task(f"Removing {xz_fpath}…")
             try:
                 xz_fpath.unlink(missing_ok=True)
@@ -58,51 +125,4 @@ class DownloadImage(Step):
             else:
                 logger.succeed_task()
 
-        # download straight to final destination
-        else:
-            logger.start_task(
-                f"Downloading {base_file} into {payload['options'].output_path}…"
-            )
-            try:
-                download_file(base_file.geturl(), payload["options"].output_path)
-            except Exception as exc:
-                logger.fail_task(str(exc))
-                return 1
-            else:
-                logger.succeed_task(
-                    format_size(get_filesize(payload["options"].output_path))
-                )
-        return 0
-
-    def run_local(self, base_file: File, payload: Dict[str, Any]) -> int:
-        # we'll extract it to destination directly
-        if base_file.getpath().suffix == ".xz":
-            logger.start_task(
-                f"Extracting {base_file.getpath()} "
-                f"into {payload['options'].output_path}…"
-            )
-            try:
-                extract_xz_image(base_file.getpath(), payload["options"].output_path)
-            except Exception as exc:
-                logger.fail_task(str(exc))
-                return 1
-            else:
-                logger.succeed_task(
-                    format_size(get_filesize(payload["options"].output_path))
-                )
-        # we'll simply copy it to destination
-        else:
-            logger.start_task(
-                f"Copying {base_file.getpath()} "
-                f"into {payload['options'].output_path}…"
-            )
-            try:
-                shutil.copy2(base_file.getpath(), payload["options"].output_path)
-            except Exception as exc:
-                logger.fail_task(str(exc))
-                return 1
-            else:
-                logger.succeed_task(
-                    format_size(get_filesize(payload["options"].output_path))
-                )
         return 0

--- a/src/image_creator/steps/cache.py
+++ b/src/image_creator/steps/cache.py
@@ -1,0 +1,83 @@
+import pathlib
+from typing import Any, Dict
+
+from image_creator.cache.manager import CacheManager
+from image_creator.cache.policy import MainPolicy
+from image_creator.constants import logger
+from image_creator.steps import Step
+from image_creator.utils.misc import supports_xattr
+
+
+class CheckCache(Step):
+    name = "Checking Cache Policy…"
+
+    def run(self, payload: Dict[str, Any]) -> int:
+        if not payload["options"].cache_dir:
+            logger.add_task("Not using cache")
+            payload["cache"] = CacheManager(pathlib.Path(), MainPolicy.disabled())
+            return 0
+
+        # check cache folder
+        payload["options"].cache_dir.mkdir(parents=True, exist_ok=True)
+
+        logger.start_task(
+            f"Checking user_xattr support at {payload['options'].cache_dir}"
+        )
+        if not supports_xattr(payload["options"].cache_dir):
+            logger.fail_task("cache must be on ext4 with `user_xattr`")
+            return 1
+        else:
+            logger.succeed_task()
+
+        # load MainPolicy
+        policy_fpath = payload["options"].cache_dir / "policy.yaml"
+        logger.start_task(f"Reading cache policy at {policy_fpath}…")
+
+        if not policy_fpath.exists():
+            policy = MainPolicy.defaults()
+            logger.fail_task("Not present ; using defaults")
+        else:
+            try:
+                policy = MainPolicy.read_from(policy_fpath.read_text())
+            except Exception as exc:
+                logger.fail_task(f"Failed to parse cache policy: {exc}")
+                return 1
+            logger.succeed_task()
+
+        logger.start_task(f"Preparing cache at {policy_fpath.parent}")
+        try:
+            payload["cache"] = CacheManager(policy_fpath.parent, policy)
+            payload["cache"].walk()
+        except Exception as exc:
+            logger.fail_task(f"Failed to initialize cache: {exc}")
+            raise exc
+            return 1
+
+        logger.succeed_task()
+        return 0
+
+
+class PrintingCache(Step):
+    name = "Printing Cache Content…"
+
+    def run(self, payload: Dict[str, Any]) -> int:
+        payload["cache"].print(with_evictions=True)
+        return 0
+
+
+class ApplyCachePolicy(Step):
+    name = "Enforcing Cache Policy…"
+
+    def run(self, payload: Dict[str, Any]) -> int:
+
+        entries = payload["cache"].apply() + payload["cache"].evict_outdated()
+        for entry, reason, succeeded in entries:
+            logger.start_task(f"Evicting {entry.source}")
+            if succeeded:
+                logger.succeed_task(f"({reason})")
+            else:
+                logger.fail_task(f"failed to evict {reason}")
+        if not entries:
+            logger.add_task("No entry to evict")
+
+        return 0

--- a/src/image_creator/steps/machine.py
+++ b/src/image_creator/steps/machine.py
@@ -2,6 +2,7 @@ from image_creator.constants import logger
 from image_creator.logger import Status
 from image_creator.steps import GivingFeedback, VirtualInitStep
 from image_creator.steps.base import DownloadImage
+from image_creator.steps.cache import ApplyCachePolicy, CheckCache, PrintingCache
 from image_creator.steps.check_inputs import (
     CheckInputs,
     CheckRequirements,
@@ -28,6 +29,9 @@ class StepMachine:
         VirtualInitStep,
         CheckRequirements,
         CheckInputs,
+        CheckCache,
+        PrintingCache,
+        ApplyCachePolicy,
         CheckURLs,
         ComputeSizes,
         # check-only stops here
@@ -55,6 +59,12 @@ class StepMachine:
         """reduce StepMachine to end with that step"""
         index = [stepcls.__name__ for stepcls in cls.steps].index(step)
         cls.steps = cls.steps[: index + 1]
+
+    @classmethod
+    def remove_step(cls, step: str):
+        """reduce StepMachine to end with that step"""
+        stepcls = [stepcls for stepcls in cls.steps if stepcls.__name__ == step][0]
+        cls.steps.remove(stepcls)
 
     def _get_step(self, index: int):
         return self.steps[index].__call__()

--- a/src/image_creator/steps/oci_images.py
+++ b/src/image_creator/steps/oci_images.py
@@ -1,9 +1,11 @@
+import pathlib
+import shutil
 from typing import Any, Dict
 
 from image_creator.constants import logger
 from image_creator.steps import Step
-from image_creator.utils.misc import format_size, get_filesize, rmtree
-from image_creator.utils.oci_images import download_image
+from image_creator.utils.misc import copy_file, format_size, get_filesize, rmtree
+from image_creator.utils.oci_images import OCIImage, download_image
 
 
 class DownloadingOCIImages(Step):
@@ -23,17 +25,53 @@ class DownloadingOCIImages(Step):
         else:
             logger.succeed_task(images_dir)
 
-        for image in payload["config"].oci_images:
-            target = images_dir.joinpath(f"{image.fs_name}.tar")
+        for image in payload["config"].all_images:
+            target = images_dir.joinpath(f"{image.oci.fs_name}.tar")
+            if image in payload["cache"]:
+                logger.start_task(f"Copying OCI Image {image} from cache…")
+                try:
+                    copy_file(payload["cache"][image].fpath, target)
+                    payload["cache"][image] += 1
+                except Exception as exc:
+                    logger.fail_task(str(exc))
+                    return 1
+                else:
+                    logger.succeed_task(format_size(get_filesize(target)))
+                    continue
+
             logger.add_task(
                 f"Downloading OCI Image to {target.relative_to(mount_point)}…"
             )
             try:
-                download_image(image=image, dest=target, build_dir=build_dir)
+                download_image(image=image.oci, dest=target, build_dir=build_dir)
             except Exception as exc:
                 logger.fail_task(str(exc))
                 rmtree(build_dir)
                 return 1
             else:
                 logger.complete_download(target.name, format_size(get_filesize(target)))
+                if payload["cache"].should_cache(image):
+                    logger.start_task(f"Adding OCI Image {image} to cache…")
+                    if payload["cache"].introduce(image, target):
+                        logger.succeed_task()
+                    else:
+                        logger.fail_task()
+
         return 0
+
+    def copy_from_cache(
+        self,
+        payload: Dict[str, Any],
+        image: OCIImage,
+        mount_point: pathlib.Path,
+        target: pathlib.Path,
+    ):
+        logger.add_task(f"Copying cached image to {target.relative_to(mount_point)}…")
+        try:
+            shutil.copy2(payload["cache"][image].fpath, target)
+        except Exception as exc:
+            logger.fail_task(str(exc))
+            return False
+        else:
+            logger.complete_download(target.name, format_size(get_filesize(target)))
+        return True

--- a/src/image_creator/steps/sizes.py
+++ b/src/image_creator/steps/sizes.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 from image_creator.constants import logger
 from image_creator.steps import Step
-from image_creator.utils.misc import format_size, parse_size
+from image_creator.utils.misc import format_size
 
 
 class ComputeSizes(Step):
@@ -10,9 +10,11 @@ class ComputeSizes(Step):
 
     def run(self, payload: Dict[str, Any]) -> int:
 
-        payload["output_size"] = parse_size(payload["config"].dig("output.size"))
+        payload["output_size"] = payload["config"].output.size
         logger.add_task("Image size:", f"{format_size(payload['output_size'])}")
 
+        for image in payload["config"].all_images:
+            ...
         # TODO: we should do more
         # - compute size of all content
         # - display cumulative size of content

--- a/src/image_creator/utils/download.py
+++ b/src/image_creator/utils/download.py
@@ -130,6 +130,13 @@ def get_digest(url: str, etag_only: Optional[bool] = False) -> str:
 
     resp = session.get(url, stream=True)
     resp.raise_for_status()
+
+    # if there has been redirects, loop through each in order,
+    # looking for MirrorBrain's Digest header and use it
+    for hist_resp in resp.history:
+        if hist_resp.headers.get("Digest"):
+            return hist_resp.headers.get("Digest")
+
     etag = resp.headers.get("ETag")
     if etag:
         etag = re.sub(r'^"(.+)"$', r"\1", etag)

--- a/src/image_creator/utils/download.py
+++ b/src/image_creator/utils/download.py
@@ -1,8 +1,11 @@
 import io
 import pathlib
+import re
 from typing import Callable, Dict, Optional, Union
 
 import requests
+
+from image_creator.utils.misc import is_http
 
 session = requests.Session()
 # basic urllib retry mechanism.
@@ -107,3 +110,36 @@ def download_file(
     else:
         fp.seek(0)
     return total_downloaded, resp.headers
+
+
+def get_digest(url: str, etag_only: Optional[bool] = False) -> str:
+    """Digest for an arbitrary URI -- or empty string
+
+    Returns:
+    - ETag (value) if found
+    - A commbination of of Content-Length and Last-Modified headers if both are present
+    - "" if etag not found and etag_only set
+    - "" if etag not found and either Content-Length or Last-Modified if not found
+
+    Should be enough to query whether an URL has been updated or not. If server
+    doesn't specify those headers, resource should be considered updated"""
+
+    # work only on http(s) URLs
+    if not is_http(url):
+        return ""
+
+    resp = session.get(url, stream=True)
+    resp.raise_for_status()
+    etag = resp.headers.get("ETag")
+    if etag:
+        etag = re.sub(r'^"(.+)"$', r"\1", etag)
+
+    if etag or etag_only:
+        return etag
+
+    length = resp.headers.get("Content-Length")
+    modified = resp.headers.get("Last-Modified")
+    if not length or not modified:
+        return ""
+
+    return f"{length}|{modified}"

--- a/src/image_creator/utils/file.py
+++ b/src/image_creator/utils/file.py
@@ -1,0 +1,118 @@
+import pathlib
+import shutil
+import urllib.parse
+from typing import Dict, Optional, Union
+
+from image_creator.constants import DATA_PART_PATH
+from image_creator.utils.download import get_online_rsc_size
+from image_creator.utils.misc import get_filesize
+
+
+class File:
+    """In-Config reference to a file to write to the data partition
+
+    Created from files entries in config:
+    - to: str
+        mandatory destination to save file into. Must be inside /data
+    - size: optional[int]
+        size of (expanded) content. If specified, must be >= source file
+    - via: optional[str]
+        method to process source file (not for content). Values in File.unpack_formats
+    - url: optional[str]
+        URL to download file from
+    - content: optional[str]
+        plain text content to write to destination
+
+    one of content or url must be supplied. content has priority"""
+
+    kind: str = "file"  # Item interface
+
+    unpack_formats = [f[0] for f in shutil.get_unpack_formats()]
+
+    def __init__(self, payload: Dict[str, Union[str, int]]):
+        self.url = None
+        self.content = payload.get("content")
+
+        if not self.content:
+            try:
+                self.url = urllib.parse.urlparse(payload.get("url"))
+            except Exception:
+                raise ValueError(f"URL “{payload.get('url')}” is incorrect")
+
+        self.to = pathlib.Path(payload["to"]).resolve()
+        if not self.to.is_relative_to(DATA_PART_PATH):
+            raise ValueError(f"{self.to} not a descendent of {DATA_PART_PATH}")
+
+        self.via = payload.get("via", "direct")
+        if self.via not in ("direct", "unzip", "untar"):
+            raise NotImplementedError(f"Unsupported handler `{self.via}`")
+
+        # initialized has unknown
+        self._size = payload.get("size", -1)
+
+    @property
+    def source(self) -> str:  # Item interface
+        return self.geturl()
+
+    @property
+    def size(self):  # Item interface
+        if self._size < 0:
+            return self.fetch_size()
+        return self._size
+
+    def fetch_size(self, force: Optional[bool] = False) -> int:
+        """retrieve size of source, making sure it's reachable"""
+        if not force and self._size >= 0:
+            return self._size
+        self._size = (
+            get_filesize(self.getpath())
+            if self.is_local
+            else get_online_rsc_size(self.geturl())
+        )
+        return self._size
+
+    def geturl(self) -> str:
+        """URL as string"""
+        try:
+            return self.url.geturl()
+        except Exception:
+            return None
+
+    def getpath(self) -> pathlib.Path:
+        """URL as a local path"""
+        return pathlib.Path(self.url.path).expanduser().resolve()
+
+    @property
+    def is_direct(self):
+        return self.via == "direct"
+
+    @property
+    def is_plain(self) -> bool:
+        """whether a plain text content to be written"""
+        return self.content is not None
+
+    @property
+    def is_local(self) -> bool:
+        """whether referencing a local file"""
+        return not self.is_plain and self.url and self.url.scheme == "file"
+
+    @property
+    def is_remote(self) -> bool:
+        """whether referencing a remote file"""
+        return self.content is None and self.url and self.url.scheme != "file"
+
+    def mounted_to(self, mount_point: pathlib.Path):
+        """destination (to) path inside mount-point"""
+        return mount_point.joinpath(self.to.relative_to(DATA_PART_PATH))
+
+    def __repr__(self) -> str:
+        msg = f"File(to={self.to}, via={self.via}"
+        if self.url:
+            msg += f", url={self.geturl()}"
+        if self.content:
+            msg += f", content={self.content.splitlines()[0][:10]}"
+        msg += f", size={self.size})"
+        return msg
+
+    def __str__(self) -> str:
+        return repr(self)

--- a/src/image_creator/utils/misc.py
+++ b/src/image_creator/utils/misc.py
@@ -1,12 +1,19 @@
+import datetime
+import inspect
 import lzma
 import os
 import pathlib
+import re
 import shutil
 import tarfile
+import tempfile
 import zipfile
-from typing import Dict
+from contextlib import suppress
+from functools import wraps
+from typing import Any, Dict, List, Optional, _SpecialForm, get_origin
 
 import humanfriendly
+import xattr
 
 
 def format_size(size: int) -> str:
@@ -17,6 +24,21 @@ def format_size(size: int) -> str:
 def parse_size(size: str) -> int:
     """size in bytes of a human-readable size representation"""
     return humanfriendly.parse_size(size)
+
+
+def format_dt(dt: datetime.datetime) -> str:
+    """std formatted datetime"""
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def parse_duration(duration: str) -> int:
+    """duration in seconds of a human-readable duration representation"""
+    return int(humanfriendly.parse_timespan(duration))
+
+
+def format_duration(duration: int) -> str:
+    """human-readble duration from seconds (1 week, 2 days)"""
+    return humanfriendly.format_timespan(duration)
 
 
 def get_filesize(fpath: pathlib.Path) -> int:
@@ -92,3 +114,143 @@ def expand_file(src: pathlib.Path, method: str, dest: pathlib.Path):
             raise IOError(f"{method} file contains out-of-bound member path: {name}")
 
     return shutil.unpack_archive(src, dest, method)
+
+
+class SimpleAttrs(xattr.xattr):
+    """Simple xattr wrapper to save specifying user. prefix"""
+
+    def __init__(self, path: pathlib.Path):
+        super().__init__(str(path))
+
+    @classmethod
+    def usered(cls, name: str) -> str:
+        return f"user.{cls.unusered(name)}"
+
+    @classmethod
+    def unusered(cls, name: str) -> str:
+        return re.sub(r"^user.", "", name)
+
+    def get(self, name: str) -> str:
+        return super().get(self.usered(name)).decode("UTF-8")
+
+    def set(self, name: str, value: str):
+        return super().set(self.usered(name), value.encode("UTF-8"))
+
+    def list(self) -> List[str]:
+        return [self.unusered(name) for name in super().list()]
+
+
+def device_supports(dev_path: str, fs: str, option: str) -> bool:
+    """whether device, mounted as `fs` has fs-option `option` enabled"""
+    try:
+        options = pathlib.Path(
+            f"/proc/fs/{fs}/{pathlib.Path(dev_path).resolve().name}/options"
+        ).read_text()
+    except Exception:
+        return False
+    return bool(re.search(rf"^{option}", options, re.MULTILINE))
+
+
+def supports_xattr(path: pathlib.Path) -> bool:
+    """whether path's filesystem supports user_xattr"""
+    path = path.resolve()
+    for line in pathlib.Path("/proc/mounts").read_text().splitlines():
+        device, mount, fs, _ = line.split(" ", 3)
+        mp = pathlib.Path(mount)
+        if path.is_relative_to(mp) and mp.stat().st_dev == path.stat().st_dev:
+            return device_supports(device, fs, "user_xattr")
+
+    def test_xattr(test_path: pathlib.Path) -> bool:
+        test_path.touch()
+        try:
+            attrs = SimpleAttrs(test_path)
+            attrs.list()
+            attrs["flag"] = "value"
+            if attrs["flag"] != "value":
+                return False
+        except Exception:
+            return False
+        return True
+
+    if path.is_file():
+        return test_xattr(path)
+
+    with tempfile.NamedTemporaryFile(dir=path) as tmp:
+        return test_xattr(pathlib.Path(tmp.name))
+
+
+def is_dict(value: Any, accepts_none: Optional[bool] = False) -> bool:
+    """whether value is a Dict (shortcut)"""
+    return isinstance(value, dict)
+
+
+def is_list(value: Any, accepts_none: Optional[bool] = False) -> bool:
+    """whether value is a List (shortcut)"""
+    return isinstance(value, list)
+
+
+def is_list_of_dict(value: Any, accepts_none: Optional[bool] = False) -> bool:
+    """whether value is a list for which each element is a Dict (shortcut)"""
+    if not is_list(value, accepts_none):
+        return False
+
+    if accepts_none and value is None:
+        return True
+
+    return all([is_dict(item, False) for item in value])
+
+
+def copy_file(src_path: pathlib.Path, dest_path: pathlib.Path):
+    """Copy src into dest"""
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src_path, dest_path)
+
+
+def is_http(url: str) -> bool:
+    """whether this URL is using HTTP(s) protocol"""
+    return re.match(r"https?://", url)
+
+
+class IncorectType(TypeError):
+    def __init__(self, where: str, field: str, expected: str, found: type):
+        self.where = where
+        self.field = field
+        self.expected = expected
+        self.found = found
+        super().__init__(f"{where}.{field} expects {expected}, not {found.__name__}")
+
+
+def enforce_types(callable):
+    spec = inspect.getfullargspec(callable)
+
+    def check_types(*args, **kwargs):
+        parameters = dict(zip(spec.args, args))
+        parameters.update(kwargs)
+        for name, value in parameters.items():
+            with suppress(KeyError):  # Assume un-annotated parameters can be any type
+                type_hint = spec.annotations[name]
+                if isinstance(type_hint, _SpecialForm):
+                    # No check for Any, Union, ClassVar
+                    # without parameters
+                    continue
+                actual_type = get_origin(type_hint) or type_hint
+                if isinstance(actual_type, _SpecialForm):
+                    # case of typing.Union[…] or typing.ClassVar[…]
+                    actual_type = type_hint.__args__
+
+                if not isinstance(value, actual_type):
+                    raise IncorectType(callable.__name__, name, type_hint, type(value))
+
+    def decorate(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            check_types(*args, **kwargs)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    if inspect.isclass(callable):
+        callable.__init__ = decorate(callable.__init__)
+        return callable
+
+    return decorate(callable)

--- a/src/image_creator/utils/oci_images.py
+++ b/src/image_creator/utils/oci_images.py
@@ -1,13 +1,47 @@
 import logging
 import pathlib
+from typing import Any, Dict
 
-from docker_export import Image, Platform, RegistryAuth, export, get_layers_manifest
+from docker_export import (
+    Image,
+    Platform,
+    RegistryAuth,
+    export,
+    get_layers_from_v1_manifest,
+    get_layers_manifest,
+    get_manifests,
+)
 from docker_export import logger as de_logger
 
 from image_creator.constants import logger
 
 de_logger.setLevel(logging.WARNING)  # reduce docker-export logging
 platform = Platform.parse("linux/arm64/v8")  # our only target arch
+
+
+class OCIImage:
+    kind: str = "image"  # Item interface
+
+    def __init__(self, payload: Dict[str, Any]):
+        self.oci: Image = Image.parse(payload["ident"])
+        self.url = payload.get("url")
+        self.filesize = int(payload["filesize"])
+        self.fullsize = int(payload["fullsize"])
+        self.is_in_cache = False
+
+    @property
+    def size(self) -> int:  # Item interface
+        return self.filesize
+
+    @property
+    def source(self) -> str:  # Item interface
+        return str(self.oci)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}<{repr(self.oci)}>"
+
+    def __str__(self):
+        return str(self.oci)
 
 
 def image_exists(image: Image) -> bool:
@@ -25,3 +59,37 @@ def image_exists(image: Image) -> bool:
 def download_image(image: Image, dest: pathlib.Path, build_dir: pathlib.Path):
     """download image into a tar file at dest"""
     export(image=image, platform=platform, to=dest, build_dir=build_dir)
+
+
+def get_image_digest(image: Image) -> str:
+    """Current digest for an Image
+
+    Value of the current in-registry image for our platform.
+
+    For v1 manifests and single-arch images, this is not the same value
+    as in the registry's UI.
+    Not much of a problem for us as images to be used here should be v2/multi
+    and what's return is consistent and will be used only for comparison
+    to check if a tag has been updated or not"""
+
+    auth = RegistryAuth.init(image)
+    auth.authenticate()
+    fat_manifests = get_manifests(image, auth)
+
+    if fat_manifests["schemaVersion"] == 1:
+        return get_layers_from_v1_manifest(
+            image=image, platform=platform, manifest=fat_manifests
+        )["config"]["digest"]
+
+    # image is single-platform, thus considered linux/amd64
+    if "layers" in fat_manifests:
+        if platform != platform.default():
+            raise ValueError("Image not found (single)")
+        return fat_manifests["config"]["digest"]
+    else:
+        # multi-platform image
+        for arch_manifest in fat_manifests.get("manifests", []):
+            if platform.match(arch_manifest.get("platform", {})):
+                return arch_manifest["digest"]
+
+    raise ValueError("Image not found (multi)")

--- a/src/image_creator/utils/requirements.py
+++ b/src/image_creator/utils/requirements.py
@@ -13,7 +13,6 @@ kernel features:
         - same loop feature applies to host's kernel
         - container must be run with --privileged
     - `ext4` filesystem (most likely enabled in-kernel)
-    check whether you need t
 
 tools:
     - losetup (mount)


### PR DESCRIPTION
This introduces a local filesystem cache for remote content in order to save download resources (time , bandwidth).

The Cache is _very flexible_ and works as follows:

- `--cache-dir` cli arg specifies a local folder to hold the cache.
- A policy must be present at `policy.yaml` in that folder ; otherwise, a default one is added
- Policy specifies which content should be allowed in the cache as well as constraints.
- if `--cache-dir` is not specified, a default `disabled` cache policy is used
- so from the code's POV, there's always a cache
- cache policy is checked on start
- then a Cache is created for the `cache_dir` and that policy
- the cache is then walked to find out about existing entries
- Cache content can be shown on the console with `--show-cache`
- Cache policy is applied: entries not confirming the policy anymore are removed
- ??? Outdated entries are removed from the cache (online has changed)
- Content URLs/Images are then checked. We know which oh them are in the cache.
- Those not in cache are added to a `candidates` list
- Policy is then applied to the candidates list. those not matching policy are dropped ; those matching are marked for insertion. It's possible that existing entries gets pushed out (removed) to leave room for new ones.
- Download then happens ; checking first for cache, copying in this case. If not in cache but should be, copied to cache after download

Reminder: there are 2 types of content in image_creator:
- File (base image and all other downloads)
- OCIImage (docker images)

The cache-allowance algorithm is in `cache.manager.get_eviction_for`. It's probably easier to understand how it works by looking at the code than reading a description of it. The basic idea is that entries gets in unconditionnaly ; either when reading fs on discovery or by checking content URLs. Then the set of entries/candidates is filtered out by testing each entry in a specific order (according to Eviction Policy):
- for individual constraints like `ignore` flag or `max_age` or source protocol (we dont cache `file://`)
- for policy-level constraints like `max_size` and `max_num`.

There are several levels of embedded policies ; tested from deepest to highest:
- SubPolicy filters
- SubPolicies
- MainPolicy

The Policy documentation is pretty straightforward I believe as are outcomes (see README)

In addition to those policy-related evictions, in-cache entries are tested for outdacy: online URL is checked and it its digest has changed, we consider it outdated and evict it. This allows having permalinks in the project YAML without worrying much.

That's why we don't cache `file://`. If *source* URI must be present to check outdacy and the source is already local, there's no point in using another local copy of the file. Note that if the server (for files) doesnt supply an ETag not Content-Length+Modified Date, we have no way of knowing its *version* and consider is always outdated

An important tech point is that we need to store metadata about each files in the Cache. I chose to store them on the filesystem's extended attributes. This seems like a good choice: it's invisible, it's strongly tied to each file, it doesn't require another file or DB. It does require a compatible FS (ext4 with user_xattr for instance) but that has the default on Debian/Ubuntu for ages. We'll see hot that stands in the future. If it becomes problematic ; we'd still be able to switch to a file-backed DB easily.

- Non-entry files in the cache are ignored. A file without a `source` xattr is considered foreign.
- It means that it's not possible to add files manually to the cache. Or one would need to set all the xattr manually.
- sys admins can query/manage the cache by using the cache-related options in combination with `--check` that stops after checks.
  - `--cache-dir xxx --show-cache --check`: prints the content of the cache
  - entries can be manually removed from cache by just removing the files
- Not-cache-related change: rewrote the Config parser/feedback using the method I used for the policy parsing: using self-validating dataclasses. Removes a lot of boilerplate. More readable.

- What should be the default policy? I've set `enabled=True, max_size=10GiB` for now.
- Should we jut not cache files without digest?

Fixes #1 


## Sample output

```
❯ python src/image_creator/ --debug --cache-dir /home/reg/cache --overwrite --show-cache ./image.yaml /mnt/test2.img

  _                                                      _
 (_)_ __ ___   __ _  __ _  ___        ___ _ __ ___  __ _| |_ ___  _ __
 | | '_ ` _ \ / _` |/ _` |/ _ \_____ / __| '__/ _ \/ _` | __/ _ \| '__|
 | | | | | | | (_| | (_| |  __/_____| (__| | |  __/ (_| | || (_) | |
 |_|_| |_| |_|\__,_|\__, |\___|      \___|_|  \___|\__,_|\__\___/|_|
                    |___/                                       v1.0.0.dev0|py3.10.6


[2023-01-17 21:43:16] :: Checking system requirements…
[2023-01-17 21:43:16]    => Checking uid… ✓
[2023-01-17 21:43:16]    => Checking binary dependencies ✓
[2023-01-17 21:43:16]    => Checking loop-device capability ✓
[2023-01-17 21:43:16]    => Checking ext4 support ✓
[2023-01-17 21:43:16] :: Checking config inputs…
[2023-01-17 21:43:16]    => Reading config from /media/psf/image-creator/image.yaml ✓
[2023-01-17 21:43:16]    => Parsing config data… ✓
[2023-01-17 21:43:16]    => Making sure base and output are different… ✓
[2023-01-17 21:43:16]    => Removing target path… ✓
[2023-01-17 21:43:16]    => Testing target location… ✓ /mnt/test2.img
[2023-01-17 21:43:16] :: Checking Cache Policy…
[2023-01-17 21:43:16]    => Checking user_xattr support at /home/reg/cache ✓
[2023-01-17 21:43:16]    => Reading cache policy at /home/reg/cache/policy.yaml… ✓
[2023-01-17 21:43:16]    => Preparing cache at /home/reg/cache ✓
[2023-01-17 21:43:16] :: Printing Cache Content…

Size          Entries  Oldest               Newest
----------  ---------  -------------------  -------------------
453.68 MiB          4  2023-01-17 10:08:54  2023-01-17 21:32:12

Size        Added On               Nb. Used  Last Used            Source                                                                                             Path
----------  -------------------  ----------  -------------------  -------------------------------------------------------------------------------------------------  -----------------------------------------------------------------------------------------------------
43.38 MiB   2023-01-17 10:08:54          13  2023-01-17 21:33:05  index.docker.io/library/caddy:2.6.1-alpine                                                         images/index.docker.io/library/caddy:2.6.1-alpine
388.64 MiB  2023-01-17 15:47:31          12  2023-01-17 21:33:04  https://s3.eu-central-1.wasabisys.com/it-offspot-base-branches/offspot-base-arm64--c28e397.img.xz  files/https/s3.eu-central-1.wasabisys.com/it-offspot-base-branches/offspot-base-arm64--c28e397.img.xz
1.19 MiB    2023-01-17 21:32:12           1  2023-01-17 21:32:12  http://download.kiwix.org/zim/wikipedia_fr_test.zim                                                files/http/download.kiwix.org/zim/wikipedia_fr_test.zim
20.47 MiB   2023-01-17 21:32:12           1  2023-01-17 21:32:12  https://download.kiwix.org/zim/wikipedia_ab_all_maxi.zim                                           files/https/download.kiwix.org/zim/wikipedia_ab_all_maxi.zim

[2023-01-17 21:43:16] :: Enforcing Cache Policy…
[2023-01-17 21:43:22]    => Evicting http://download.kiwix.org/zim/wikipedia_fr_test.zim ✓ (outdated)
[2023-01-17 21:43:22]    => Evicting https://download.kiwix.org/zim/wikipedia_ab_all_maxi.zim ✓ (outdated)
[2023-01-17 21:43:22] :: Checking all Sources…
[2023-01-17 21:43:22]    => Checking https://s3.eu-central-1.wasabisys.com/it-offspot-base-branches/offspot-base-arm64--c28e397.img.xz… ✓ 388.64 MiB (cached)
[2023-01-17 21:43:22]    => Checking http://download.kiwix.org/zim/wikipedia_fr_test.zim… ✓ 1.19 MiB
[2023-01-17 21:43:24]    => Checking https://download.kiwix.org/zim/wikipedia_ab_all_maxi.zim… ✓ 20.47 MiB
[2023-01-17 21:43:26]    => Checking OCI Image index.docker.io/library/caddy:2.6.1-alpine… ✓ 43.38 MiB (cached)
[2023-01-17 21:43:28]    => Checking OCI Image ghcr.io/offspot/kiwix-serve:dev… ✓
[2023-01-17 21:43:36]    => Checking OCI Image ghcr.io/offspot/base-httpd:dev… ✓
[2023-01-17 21:43:57]    => Computing cache updates… 2 to add (21.66 MiB)
[2023-01-17 21:43:57] :: Compute sizes…
[2023-01-17 21:43:57]    => Image size: 7.45 GiB
[2023-01-17 21:43:57] :: Fetching base image
[2023-01-17 21:43:57]    => Extracting /home/reg/cache/files/https/s3.eu-central-1.wasabisys.com/it-offspot-base-branches/offspot-base-arm64--c28e397.img.xz… ✓ 2.74 GiB
[2023-01-17 21:44:25] :: Resizing image
[2023-01-17 21:44:25]    => Checking image size… ✓ 2.74 GiB
[2023-01-17 21:44:25]    => Resizing image to 8000000000b… ✓ 7.45 GiB
[2023-01-17 21:44:25]    => Getting a loop device… ✓ /dev/loop7
[2023-01-17 21:44:25]    => Attaching image to /dev/loop7… ✓
[2023-01-17 21:44:25]    => Resizing third partition of /dev/loop7… ✓
[2023-01-17 21:44:25] :: Mounting data partition
[2023-01-17 21:44:25]    => Mouting /dev/loop7p3… ✓
[2023-01-17 21:44:25] :: Downloading OCI Images
[2023-01-17 21:44:25]    => Creating OCI Images placeholder… ✓ /tmp/part3_8j5mxbam/images
[2023-01-17 21:44:25]    => Copying OCI Image index.docker.io/library/caddy:2.6.1-alpine from cache… ✓ 43.38 MiB
[2023-01-17 21:44:25]    => Downloading OCI Image to images/ghcr.io_offspot_kiwix-serve.tar…
[Elapsed Time: 0:00:08]   2.6 MiB|###############################################################|242.2 KiB/s (Time:  0:00:08)
[Elapsed Time: 0:00:00]  45.2 KiB|###############################################################| 58.6 MiB/s (Time:  0:00:00)
[Elapsed Time: 0:00:01]   8.3 MiB|###############################################################|  5.1 MiB/s (Time:  0:00:01)
[2023-01-17 21:44:46]       ✓ ghcr.io_offspot_kiwix-serve.tar 23.58 MiB
[2023-01-17 21:44:46]    => Downloading OCI Image to images/ghcr.io_offspot_base-httpd.tar…
[Elapsed Time: 0:00:00]   2.6 MiB|###############################################################|  7.4 MiB/s (Time:  0:00:00)
[Elapsed Time: 0:00:00]  51.1 KiB|###############################################################| 71.9 MiB/s (Time:  0:00:00)
[Elapsed Time: 0:00:00] 117.0 B|#################################################################|290.0 KiB/s (Time:  0:00:00)
[2023-01-17 21:44:54]       ✓ ghcr.io_offspot_base-httpd.tar 5.45 MiB
[2023-01-17 21:44:54] :: Processing local contents
[2023-01-17 21:44:54]    => Writing plain text to /data/conf/home2.yaml… ✓ 5 bytes
[2023-01-17 21:44:54]    => Writing plain text to /data/conf/home.yaml… ✓ 9.97 KiB
[2023-01-17 21:44:54]    => Writing plain text to /data/conf/Caddyfile-host… ✓ 744 bytes
[2023-01-17 21:44:54] :: Downloading content
[2023-01-17 21:44:54]    => Downloading 2 files totaling 21.66 MiB… using 2 workers
[Elapsed Time: 0:00:02]   2.2 MiB of 21.66 MiB downloaded|###                                    |  1.1 MiB/s (ETA:   0:00:25)
[2023-01-17 21:44:57]       ✓ wikipedia_fr_test.zim 1.19 MiB (cached) (1 items accounting 19.47 MiB remaining)
[Elapsed Time: 0:00:19]  21.7 MiB of 21.66 MiB downloaded|#######################################|729.4 KiB/s (ETA:  00:00:00)
[2023-01-17 21:45:13]       ✓ wikipedia_ab_all_maxi.zim 20.47 MiB (cached) (2 items completed)
[Elapsed Time: 0:00:19]  21.7 MiB of 21.66 MiB downloaded|#######################################|729.4 KiB/s (Time:  0:00:19)
[2023-01-17 21:45:13] :: Unmounting data partition
[2023-01-17 21:45:13]    => Unmouting /tmp/part3_8j5mxbam… ✓
[2023-01-17 21:45:14] :: Mounting boot partition
[2023-01-17 21:45:14]    => Mouting /dev/loop7p1… ✓
[2023-01-17 21:45:14] :: Writing Offspot Config…
[2023-01-17 21:45:14]    => Saving Offspot config to /tmp/part1_0rkae5aq/offspot.yaml… ✓
[2023-01-17 21:45:14] :: Unmounting boot partition
[2023-01-17 21:45:14]    => Unmouting /tmp/part1_0rkae5aq… ✓
[2023-01-17 21:45:14] :: Detaching Image
[2023-01-17 21:45:14]    => Detach image from /dev/loop7 ✓
[2023-01-17 21:45:14] :: Giving creation feedback
[2023-01-17 21:45:14]    => Image created successfuly ✓ /mnt/test2.img
[2023-01-17 21:45:14]  Cleaning-up… ....................
```