### PR TITLE
Added sizes checking feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Image configuration is done through a YAML file which must match the following f
 
 | Member             | Kind           | Function                                                                                                                                                           |
 |--------------------|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `base`             | `string`       | Version ([official releases](https://drive.offspot.it/base/)) or URL to a base-image file. Accepts `file://` URLs. Accepts lzma encoded images using `.xz` suffix  |
+| **`base`**         |                | Reference to the Offspot Base Image to use                                                                                                                         |
+| `base.source`      | `string`       | Version ([official releases](https://drive.offspot.it/base/)) or URL to a base-image file. Accepts `file://` URLs. Accepts lzma encoded images using `.xz` suffix  |
+| `base.root_size`   | `string`/`int` | Size of the root (system) partition in the referenced base image (used to calculate free space)                                                                    |
 | `output.size`      | `string`/`int` | Requested size of output image. Accepts `auto` for an power-of-2 sized that can fit the content (⚠️ TBI)                                                           |
 | `oci_images`       | `image[]`      | List of  OCI Image                                                                                                                                                 |
 | **`image[].id`**   | `string`       | **specific** OCI Image name. Prefer ghcr.io if possible. [Format](https://github.com/opencontainers/.github/blob/master/docs/docs/introduction/digests.md)         |

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ cli-ui==0.17.2
 humanfriendly==10.0
 progressbar2==4.2.0
 docker_export==0.4
-xattr==0.10.1

--- a/src/image_creator/cache/manager.py
+++ b/src/image_creator/cache/manager.py
@@ -312,6 +312,9 @@ class CacheManager(dict):
 
     __contains__ = in_cache
 
+    def has_candidate(self, item: Item) -> bool:
+        return path_for_item(item) in self.candidates.keys()
+
     def __len__(self):
         if not self.discovered:
             self.walk()

--- a/src/image_creator/constants.py
+++ b/src/image_creator/constants.py
@@ -4,11 +4,11 @@ import sys
 import tempfile
 import urllib.parse
 from dataclasses import dataclass
-from typing import Union
+from typing import Optional, Union
 
 from image_creator import __version__ as vers
 from image_creator.logger import Logger
-from image_creator.utils.misc import is_http
+from image_creator.utils.misc import is_http, parse_size
 
 # where will data partition be monted on final device.
 # used as reference for destinations in config file and in the UI
@@ -47,6 +47,7 @@ class Options:
     keep_failed: bool
     overwrite: bool
     concurrency: int
+    max_size: Optional[int] = None
 
     config_url: urllib.parse.ParseResult = None
     logger: Logger = Logger()
@@ -74,6 +75,9 @@ class Options:
 
         if self.CACHE_DIR:
             self.cache_dir = pathlib.Path(self.CACHE_DIR).expanduser().resolve()
+
+        if isinstance(self.max_size, str):
+            self.max_size = parse_size(self.max_size)
 
     @property
     def version(self):

--- a/src/image_creator/entrypoint.py
+++ b/src/image_creator/entrypoint.py
@@ -63,6 +63,11 @@ def main():
         help="Don't fail on existing output image: remove instead",
     )
     parser.add_argument(
+        "--max-size",
+        dest="max_size",
+        help="Maximum image size allowed. Ex: 512GB",
+    )
+    parser.add_argument(
         "-T",
         "--concurrency",
         type=int,

--- a/src/image_creator/steps/base.py
+++ b/src/image_creator/steps/base.py
@@ -18,10 +18,10 @@ class DownloadImage(Step):
 
     def run(self, payload: Dict[str, Any]) -> int:
         # we need to extract this into the actual target
-        if payload["config"].base.getpath().suffix == ".xz":
-            return self.run_compressed(payload["config"].base, payload)
+        if payload["config"].base_file.getpath().suffix == ".xz":
+            return self.run_compressed(payload["config"].base_file, payload)
 
-        return self.run_uncompressed(payload["config"].base, payload)
+        return self.run_uncompressed(payload["config"].base_file, payload)
 
     def run_uncompressed(self, base_file: File, payload: Dict[str, Any]) -> int:
         target = payload["options"].output_path

--- a/src/image_creator/steps/check_inputs.py
+++ b/src/image_creator/steps/check_inputs.py
@@ -105,33 +105,11 @@ class CheckInputs(Step):
             logger.succeed_task()
         return 0
 
-    # def check_params(self, payload: Dict[str, Any]) -> int:
-    #     logger.start_task("Checking parameters…")
-    #     try:
-    #         if not payload["config"].init():
-    #             logger.fail_task("Config file is not valid")
-    #             logger.warning(
-    #                 "\n".join(
-    #                     [
-    #                         f"- [{key}] {error}"
-    #                         for key, error in payload["config"].errors
-    #                     ]
-    #                 )
-    #             )
-    #             return 3
-    #         else:
-    #             logger.succeed_task()
-    #     except Exception as exc:
-    #         logger.fail_task(f"Config contains invalid values: {exc}")
-    #         raise exc
-    #         return 3
-    #     return 0
-
     def check_different_output(self, payload: Dict[str, Any]) -> int:
         logger.start_task("Making sure base and output are different…")
         if (
-            payload["config"].base.is_local
-            and payload["config"].base.getpath() == payload["options"].output_path
+            payload["config"].base_file.is_local
+            and payload["config"].base_file.getpath() == payload["options"].output_path
         ):
             logger.fail_task("base and output image are the same")
             return 3
@@ -216,7 +194,7 @@ class CheckURLs(Step):
     def run(self, payload: Dict[str, Any]) -> int:
         all_valid = True
 
-        for file in [payload["config"].base] + payload["config"].all_files:
+        for file in [payload["config"].base_file] + payload["config"].all_files:
             if file.is_plain:
                 continue
 

--- a/src/image_creator/steps/sizes.py
+++ b/src/image_creator/steps/sizes.py
@@ -1,8 +1,15 @@
+import pathlib
 from typing import Any, Dict
 
 from image_creator.constants import logger
 from image_creator.steps import Step
-from image_creator.utils.misc import format_size
+from image_creator.utils.misc import format_size, get_freespace
+
+
+def get_margin_for(content_size: int) -> int:
+    """margin in bytes for such a content_size"""
+
+    return int(0.1 * content_size)  # static 10% for now
 
 
 class ComputeSizes(Step):
@@ -11,18 +18,142 @@ class ComputeSizes(Step):
     def run(self, payload: Dict[str, Any]) -> int:
 
         payload["output_size"] = payload["config"].output.size
-        logger.add_task("Image size:", f"{format_size(payload['output_size'])}")
 
-        for image in payload["config"].all_images:
-            ...
-        # TODO: we should do more
-        # - compute size of all content
-        # - display cumulative size of content
-        # - display suggested minimum SD size
-        # - use that size as image size if set to `auto`
-        # - fail if `auto` but some files dont report size
-        # - check disk space on output_path.parent
-        # - failed it it wont allow the base + resize
-        # - calc how much space will be needed in the build-dir (non-direct DL)
-        # - fail if build-dir wont allow it
+        tar_images_size = sum(
+            [image.filesize for image in payload["config"].all_images]
+        )
+        expanded_images_size = sum(
+            [image.fullsize for image in payload["config"].all_images]
+        )
+        expanded_files_size = sum(
+            [file.fullsize for file in payload["config"].all_files]
+        )
+
+        raw_content_size = sum(
+            [tar_images_size, expanded_images_size, expanded_files_size]
+        )
+        margin = get_margin_for(raw_content_size)
+        min_image_size = sum(
+            [payload["config"].base.rootfs_size, raw_content_size, margin]
+        )
+
+        logger.add_task("Computed Minimum Image Size", format_size(min_image_size))
+
+        # user might have requested a specific output size ; must comply
+        if payload["config"].output.size and isinstance(
+            payload["config"].output.size, int
+        ):
+            image_size = payload["config"].output.size
+            logger.start_task("Computed size fits within requested size")
+            if payload["config"].output.size < min_image_size:
+                logger.fail_task(
+                    f"{format_size(min_image_size)} > "
+                    f"{format_size(payload['config'].output.size)}"
+                )
+                return 1
+            logger.succeed_task(
+                f"{format_size(min_image_size)} <= "
+                f"{format_size(payload['config'].output.size)}"
+            )
+        else:
+            image_size = min_image_size
+
+        # user might have requested a maximum image size to produce; must comply
+        if payload["options"].max_size:
+            logger.start_task("Computed size fits within max_size")
+            if payload["options"].max_size < image_size:
+                logger.fail_task(format_size(payload["options"].max_size))
+                return 1
+            logger.succeed_task()
+
+        return self.check_physical_space(payload, image_size)
+
+    def get_needs(self, payload: Dict[str, Any], image_size: int) -> Dict[str, int]:
+        needs = {}
+        # target volume needs:
+        # - uncompressed image file is written to it
+        # - it is later expanded
+        needs["target"] = max([payload["config"].base_file.fullsize, image_size])
+
+        # build-dir needs:
+        # files that need to be uncompressed are downloaded to first (incl. base)
+        remote_compressed_files = [
+            file for file in payload["config"].remote_files if file.via != "direct"
+        ]
+        needs["build_dir"] = sum([file.filesize for file in remote_compressed_files])
+
+        # cache needs:
+        # - what will be introduced to cache
+        if payload["options"].cache_dir:
+            needs["cache_dir"] = sum(
+                [entry.size for entry in payload["cache"].candidates.values()]
+            )
+            # exclude from build-dir the size of those we'll have in cache
+            needs["build_dir"] -= sum(
+                [
+                    file.size
+                    for file in remote_compressed_files
+                    if file in payload["cache"] or payload["cache"].has_candidate(file)
+                ]
+            )
+        return needs
+
+    def get_target_path(output_path: pathlib.Path) -> pathlib.Path:
+        """usable output path given the requested one might not exist yet"""
+
+        # at this stage, the target image file probably doesnt exists (but can)
+        # and its parent folder might not exist as well
+        if not output_path.exists():
+            for parent in output_path.parents:
+                if parent.exists():
+                    return parent
+        return output_path
+
+    def check_physical_space(self, payload: Dict[str, Any], image_size: int) -> int:
+        logger.start_task("Checking free-space availability…")
+        target_path = self.get_target_path(payload["options"].output_path)
+        needs = self.get_needs(payload)
+
+        # mapping of volumes/mount point with their cumulative needs
+        volumes_map = {}
+
+        def update_map(volume, needs: int, path: pathlib.Path):
+            if volume not in volumes_map:
+                volumes_map[volume] = {"needs": needs, "paths": [path]}
+                return
+            volumes_map[volume]["needs"] + needs
+            volumes_map[volume]["paths"].append(path)
+
+        update_map(target_path.stat().st_dev, needs["target"], target_path)
+        update_map(
+            payload["options"].build_dir.stat().st_dev,
+            needs["build_dir"],
+            payload["options"].build_dir,
+        )
+        if payload["options"].cache_dir:
+            update_map(
+                payload["options"].cache_dir.stat().st_dev,
+                needs["cache_dir"],
+                payload["options"].cache_dir,
+            )
+
+        total_needs = total_free_space = 0
+        for data in volumes_map.values():
+            free_space = get_freespace(data["paths"][0])
+            if data["needs"] > free_space:
+                missing = data["needs"] - free_space
+                paths = ", ".join([str(p) for p in data["paths"]])
+                logger.fail_task(
+                    f"missing {format_size(missing)} on disk {paths}. "
+                    f"{format_size(data['needs'])} required. "
+                    f"{format_size(free_space)} free."
+                )
+                return 1
+            total_free_space += free_space
+            total_needs += data["needs"]
+
+        logger.succeed_task(
+            f"{format_size(total_needs)} required, "
+            f"{format_size(total_free_space)} free."
+        )
         return 0

--- a/src/image_creator/utils/file.py
+++ b/src/image_creator/utils/file.py
@@ -49,6 +49,7 @@ class File:
 
         # initialized has unknown
         self._size = payload.get("size", -1)
+        self._fullsize = payload.get("fullsize", None)
 
     @property
     def source(self) -> str:  # Item interface
@@ -59,6 +60,10 @@ class File:
         if self._size < 0:
             return self.fetch_size()
         return self._size
+
+    @property
+    def fullsize(self):
+        return self._fullsize or self.size
 
     def fetch_size(self, force: Optional[bool] = False) -> int:
         """retrieve size of source, making sure it's reachable"""

--- a/src/image_creator/utils/misc.py
+++ b/src/image_creator/utils/misc.py
@@ -13,7 +13,6 @@ from functools import wraps
 from typing import Any, Dict, List, Optional, _SpecialForm, get_origin
 
 import humanfriendly
-import xattr
 
 
 def format_size(size: int) -> str:
@@ -122,11 +121,14 @@ def expand_file(src: pathlib.Path, method: str, dest: pathlib.Path):
     return shutil.unpack_archive(src, dest, method)
 
 
-class SimpleAttrs(xattr.xattr):
-    """Simple xattr wrapper to save specifying user. prefix"""
+class SimpleAttrs:
+    """Dict-like xattr wrapper to save specifying user. prefix"""
 
     def __init__(self, path: pathlib.Path):
-        super().__init__(str(path))
+        self.path = path
+
+    def __repr__(self):
+        return f"{type(self).__name__}(path={self.path})"
 
     @classmethod
     def usered(cls, name: str) -> str:
@@ -137,13 +139,86 @@ class SimpleAttrs(xattr.xattr):
         return re.sub(r"^user.", "", name)
 
     def get(self, name: str) -> str:
-        return super().get(self.usered(name)).decode("UTF-8")
+        return os.getxattr(self.path, self.usered(name)).decode("UTF-8")
 
     def set(self, name: str, value: str):
-        return super().set(self.usered(name), value.encode("UTF-8"))
+        os.setxattr(self.path, self.usered(name), value.encode("UTF-8"))
+
+    def remove(self, name: str):
+        os.removexattr(self.path, self.usered(name))
 
     def list(self) -> List[str]:
-        return [self.unusered(name) for name in super().list()]
+        return [self.unusered(name) for name in os.listxattr(self.path)]
+
+    def __len__(self) -> int:
+        return len(self.list())
+
+    def __delitem__(self, item: str):
+        try:
+            self.remove(item)
+        except IOError:
+            raise KeyError(item)
+
+    def __setitem__(self, item: str, value: str):
+        self.set(item, value)
+
+    def __getitem__(self, item: str) -> str:
+        try:
+            return self.get(item)
+        except IOError:
+            raise KeyError(item)
+
+    def iterkeys(self):
+        return iter(self.list())
+
+    __iter__ = iterkeys
+
+    def has_key(self, item: str) -> bool:
+        try:
+            self.get(item)
+        except IOError:
+            return False
+        else:
+            return True
+
+    __contains__ = has_key
+
+    def clear(self):
+        for k in self.keys():
+            del self[k]
+
+    def update(self, seq):
+        if not hasattr(seq, "items"):
+            seq = dict(seq)
+        for k, v in seq.items():
+            self[k] = v
+
+    def copy(self):
+        return dict(self.iteritems())
+
+    def setdefault(self, k, d=""):
+        try:
+            d = self.get(k)
+        except IOError:
+            self[k] = d
+        return d
+
+    def keys(self):
+        return self.list()
+
+    def itervalues(self):
+        for k, v in self.iteritems():
+            yield v
+
+    def values(self):
+        return list(self.itervalues())
+
+    def iteritems(self):
+        for k in self.list():
+            yield k, self.get(k)
+
+    def items(self):
+        return list(self.iteritems())
 
 
 def device_supports(dev_path: str, fs: str, option: str) -> bool:

--- a/src/image_creator/utils/misc.py
+++ b/src/image_creator/utils/misc.py
@@ -64,6 +64,12 @@ def get_size_of(fpath: pathlib.Path) -> int:
     return get_dirsize(fpath)
 
 
+def get_freespace(fpath: pathlib.Path) -> int:
+    """free-space in bytes for the volume at fpath"""
+    stat = os.statvfs(fpath)
+    return stat.f_bavail * stat.f_frsize
+
+
 def rmtree(fpath: pathlib.Path):
     """recursively remove an entire folder (rm -rf)"""
     shutil.rmtree(fpath, ignore_errors=True)


### PR DESCRIPTION
Before starting the main process of downloading and copying content into the image,
it is important to check that size constraints are met:
- size of content to go into the image (if a size was specified) will fit
- image size is under the maximum image size (if set ; new feature to set worker limits)
- disk space is available to process it all:
  - download (and maybe extract) base image
  - expand base image in target directory
  - download temp-files (those that needs to be extracted) into build-dir
  - download to-cache file into cache-dir

## Root filesystem issue

In order to calculate image size properly, the code needs to know the size that the
root filesystem in the base image occupies.

This information is missing and, from the base image file, can only be obtained after
it has been downloaded, extracted (if xz) and attached.
Problem being: we want to known before all download tasks whether the image request
can be satisfied or not.

Options to solve this:

### A. Use base image file

We could defer the size computation step to after the base image has been retrieved
and attached.
It doesn't require any other input but it creates a possibility of failure if retrieving
the base image is not possible, due to filesize for instance.
We'd want to check that first and thus it would create two check steps reducing the
advantage of a single *all-good or failed* single step check.

### B. Request root filesystem size in image.yaml

That's the simplest and most straightforward option. Following other similar requirements
(for OCI images for instance), the base rootfs size would be mandatory.
Should the given value be incorrect (lower than reality), process would fail at attaching step.

This requires another to-be-known information while the previous behavior 
of a single version or file URL was very convenient.

**that's what's currently implemented**

### C. include information in base image file/archive

We could imagine appending the root fs size when building the base image

- to the .img file at a specific offset (end of file) but it would not be explicit, may break ability to just flash the base image directly
- to the .xz file as another file but it would be unexpected and not pigen-like which only compresses the .img file. Also, we want to support uncompressed img as well.

So, very hackish

### D. include information in a distinct file

When releasing a base image, we could upload a companion file (json? text?) that would have the same filename but with a dedicated suffix.
In conjunction with option B, if not set in image.yaml, code would try that companion file URL and use it if found.
This would mean a friction-less use for all *our releases* with the ability to input it manually in absence of the companion.


### E. Request WANTED root filesystem size

If requesting a rootfs size, we could consider it not an information but a request.
In this case, we'd not resize the third partition but delete it, resize the root partition
and then recreate the third partition.

Such a feature might be handy some day (given needs evolve differently than base) but
it's additional work for something that's not needed at this point.


## Notes

- Only the first check calculating required image size and defining a margin would be shareable with higher-level tools.
- Added a new `--max-size` option allowing out-of-config bound to match resources (max size creatable by worker for instance)
- `base` config change from single string to dict with `source` and `rootfs_size`
